### PR TITLE
Updated readme instructions around brew cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,9 @@ Check out these great alternatives:
 ## Installation from Homebrew Cask
 
 [Homebrew cask](http://caskroom.io/) is the easiest way to install binary applications and quicklook plugins.
-If you have [homebrew](http://brew.sh/) - use 3 lines below and you are ready.
+If you have [homebrew](http://brew.sh/) - use the line below and you are ready.
 
 ```
-# Cask install
-brew tap caskroom/cask
-brew install brew-cask
-
 # ProvisionQL install
 brew cask install provisionql
 ```


### PR DESCRIPTION
Brew cask is now bundled in brew so there is only one command needed to install ProvisionQL