### PR TITLE
Fix Issue #3: Read code signing entitlements from the application binary

### DIFF
--- a/ProvisionQL/Shared.h
+++ b/ProvisionQL/Shared.h
@@ -8,7 +8,7 @@
 
 #import <NSBezierPath+IOS7RoundedRect.h>
 
-static NSString * const kPluginBundleId = @"com.FerretSyndicate.ProvisionQL";
+static NSString * const kPluginBundleId = @"com.ealeksandrov.ProvisionQL";
 static NSString * const kDataType_ipa               = @"com.apple.itunes.ipa";
 static NSString * const kDataType_app               = @"com.apple.application-bundle";
 static NSString * const kDataType_ios_provision     = @"com.apple.mobileprovision";

--- a/ProvisionQL/Supporting-files/Info.plist
+++ b/ProvisionQL/Supporting-files/Info.plist
@@ -31,7 +31,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1</string>
 	<key>CFBundleVersion</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFPlugInDynamicRegisterFunction</key>
 	<string></string>
 	<key>CFPlugInDynamicRegistration</key>


### PR DESCRIPTION
Implement reading the code signing entitlements directly from the application binary,
instead of loading them from the provisioning profile.

This is useful because the provisioning profile will always have some entitlements set to wildcards, and will not reflect the actual entitlements being used by the app (eg. `keychain-access-groups`).

The application binary filename is read from the info.plist, extracted from the IPA (if necessary),
and the output from `codesign -d <AppBinary> --entitlements :-` is saved.

When replacing the entitlements section in the HTML, check if there are entitlements from the output of codesign and use them.
If there are none, fallback to the previous code, and read them from the provisioning profile.