### PR TITLE
Support dark mode

### DIFF
--- a/ProvisionQL/Resources/template.html
+++ b/ProvisionQL/Resources/template.html
@@ -6,6 +6,7 @@
             <style>
                 body {
                     background: #f7f7f7;
+                    color: #000;
                     margin: 20px;
                     font: 13px courier, monospaced, sans-serif;
                     line-height: 1.3;
@@ -102,6 +103,35 @@
                     margin-top: 20px;
                     color: #aaa;
                     font-size: 11px;
+                }
+
+                @media (prefers-color-scheme: dark) {
+                    body {
+                        background: #323232;
+                        color: #fff;
+                    }
+
+                    a         { color: #aaa; }
+                    a:hover   { color: #fff; }
+                    a:visited { color: #aaa; }
+
+                    .expired {
+                        color: red;
+                    }
+                    .expiring {
+                        color: orange;
+                    }
+                    .valid {
+                        color: lightgreen;
+                    }
+
+                    tr:nth-child(odd) {
+                        background-color: #292929;
+                    }
+
+                    tr:nth-child(even) {
+                        background-color: #1e1e1e;
+                    }
                 }
                 </style>
             </head>

--- a/ProvisionQL/Resources/template.html
+++ b/ProvisionQL/Resources/template.html
@@ -8,7 +8,7 @@
                     background: #f7f7f7;
                     color: #000;
                     margin: 20px;
-                    font: 13px courier, monospaced, sans-serif;
+                    font: 13px monospace;
                     line-height: 1.3;
                 }
 
@@ -22,6 +22,7 @@
 
                 .app img {
                     -webkit-filter: drop-shadow(0px 0px 3px rgba(0,0,0,0.5));
+                    filter: drop-shadow(0px 0px 3px rgba(0,0,0,0.5));
                     max-width: 60px;
                 }
 


### PR DESCRIPTION
Requires macOS 10.14.4

Also:
- Change font family to just `monospace`
- Add `filter` CSS property for future-proofing

<img width="942" alt="Screenshot" src="https://user-images.githubusercontent.com/6135313/55015542-04be3900-5028-11e9-854e-f2ff816f42d6.png">
