### PR TITLE
Extensions support

### DIFF
--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -371,6 +371,14 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
             [synthesizedInfo setObject:[appPropertyList objectForKey:@"CFBundleShortVersionString"] forKey:@"CFBundleShortVersionString"];
             [synthesizedInfo setObject:[appPropertyList objectForKey:@"CFBundleVersion"] forKey:@"CFBundleVersion"];
 
+            NSString *extensionType = [[appPropertyList objectForKey:@"NSExtension"] objectForKey:@"NSExtensionPointIdentifier"];
+            if(extensionType != nil) {
+                [synthesizedInfo setObject:@"" forKey:@"ExtensionInfo"];
+                [synthesizedInfo setObject:extensionType forKey:@"NSExtensionPointIdentifier"];
+            } else {
+                [synthesizedInfo setObject:@"hiddenDiv" forKey:@"ExtensionInfo"];
+            }
+
             NSString *sdkName = [appPropertyList objectForKey:@"DTSDKName"] ?: @"";
             [synthesizedInfo setObject:sdkName forKey:@"DTSDKName"];
 

--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -316,6 +316,12 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
                     codesignEntitlementsData = codesignEntitlementsDataFromApp(appPlist, appURL.path);
                 }
             }
+        } else if ([dataType isEqualToString:kDataType_app_extension]) {
+            // get embedded plist and provisioning
+            provisionData = [NSData dataWithContentsOfURL:[URL URLByAppendingPathComponent:@"embedded.mobileprovision"]];
+            appPlist = [NSData dataWithContentsOfURL:[URL URLByAppendingPathComponent:@"Info.plist"]];
+            // read codesigning entitlements from application binary
+            codesignEntitlementsData = codesignEntitlementsDataFromApp(appPlist, URL.path);
         } else {
             // use provisioning directly
             provisionData = [NSData dataWithContentsOfURL:URL];
@@ -333,6 +339,8 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
 
         if ([dataType isEqualToString:kDataType_ipa]) {
             [synthesizedInfo setObject:@"App info" forKey:@"AppInfoTitle"];
+        } else if ([dataType isEqualToString:kDataType_app_extension]) {
+            [synthesizedInfo setObject:@"App extension info" forKey:@"AppInfoTitle"];
         } else if ([dataType isEqualToString:kDataType_xcode_archive]) {
             [synthesizedInfo setObject:@"Archive info" forKey:@"AppInfoTitle"];
         }
@@ -340,7 +348,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
         if (!provisionData) {
 			NSLog(@"No provisionData for %@", URL);
 
-            if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
+            if (appPlist != nil) {
                 [synthesizedInfo setObject:@"hiddenDiv" forKey:@"ProvisionInfo"];
             } else {
                 return noErr;
@@ -351,7 +359,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
 
         // MARK: App Info
 
-        if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
+        if (appPlist != nil) {
             NSDictionary *appPropertyList = [NSPropertyListSerialization propertyListWithData:appPlist options:0 format:NULL error:NULL];
 
             NSString *bundleName = [appPropertyList objectForKey:@"CFBundleDisplayName"];
@@ -455,7 +463,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
         NSData *data = (NSData *)CFBridgingRelease(dataRef);
         CFRelease(decoder);
 
-        if ((!data && !([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive])) || QLPreviewRequestIsCancelled(preview)) {
+        if ((!data && !appPlist) || QLPreviewRequestIsCancelled(preview)) {
             return noErr;
         }
 

--- a/ProvisionQL/Resources/template.html
+++ b/ProvisionQL/Resources/template.html
@@ -144,6 +144,9 @@
 				Name: <strong>__CFBundleName__</strong><br />
 				Version: __CFBundleShortVersionString__ (__CFBundleVersion__)<br />
 				BundleId: __CFBundleIdentifier__<br />
+                <div class="extension __ExtensionInfo__">
+                    Extension type: __NSExtensionPointIdentifier__<br />
+                </div>
 				DeviceFamily: __UIDeviceFamily__<br />
                 SDK: __DTSDKName__<br />
                 Minimum OS Version: __MinimumOSVersion__<br />

--- a/ProvisionQL/Shared.h
+++ b/ProvisionQL/Shared.h
@@ -14,6 +14,7 @@ static NSString * const kDataType_ios_provision     = @"com.apple.mobileprovisio
 static NSString * const kDataType_ios_provision_old = @"com.apple.iphone.mobileprovision";
 static NSString * const kDataType_osx_provision     = @"com.apple.provisionprofile";
 static NSString * const kDataType_xcode_archive     = @"com.apple.xcode.archive";
+static NSString * const kDataType_app_extension     = @"com.apple.application-and-system-extension";
 
 NSImage *roundCorners(NSImage *image);
 NSImage *imageFromApp(NSURL *URL, NSString *dataType, NSString *fileName);


### PR DESCRIPTION
## Description

I've noticed that QuickLook doesn't work for any app extensions, although they should be supported. When debugging, I've found that they are missing provision data, so QuickLook fails without analysing `Info.plist`.

## Changes

- Add `provisionData` and `appPlist` initializers for app extensions.
- When `appPlist != nil && provisionData == nil` - hide provisioning section, but continue previewing `Info.plist` data.
- Add specific header title for app extensions.
- Add `Extension type` info field for app extensions.

## Test

1. Install debug version of ProvisionQL to `~/Library/QuickLook/`.
2. Unzip test .ipa, navigate to the extensions folder: `*.ipa/Payload/*.app/PlugIns/*.appex`.
3. Hit space to trigger QuickLook on any app extension.

## Screenshots

before | after
--|--
![](https://user-images.githubusercontent.com/3132438/232427680-c981c34d-35ea-40d1-b888-f0d1856b4ee9.png)|![](https://user-images.githubusercontent.com/3132438/232427688-14ddee47-1f46-4cfc-87fb-c8baa175941f.png)

