### PR TITLE
Handle error when parsing entitlements plist

### DIFF
--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -540,6 +540,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
                 [synthesizedInfo setObject:synthesizedValue forKey:@"TeamIds"];
             }
 
+            BOOL showEntitlementsWarning = false;
             if (codesignEntitlementsData != nil) {
                 // read the entitlements directly from the codesign output
                 NSDictionary *entitlementsPropertyList = [NSPropertyListSerialization propertyListWithData:codesignEntitlementsData options:0 format:NULL error:NULL];
@@ -557,6 +558,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
                     } else {
                         errorOutput = outputString;
                     }
+                    showEntitlementsWarning = true;
                     synthesizedValue = errorOutput;
                 }
                 [synthesizedInfo setObject:synthesizedValue forKey:@"EntitlementsFormatted"];
@@ -573,6 +575,11 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
                 } else {
                     [synthesizedInfo setObject:@"No Entitlements" forKey:@"EntitlementsFormatted"];
                 }
+            }
+            if (showEntitlementsWarning) {
+                [synthesizedInfo setObject:@"" forKey:@"EntitlementsWarning"];
+            } else {
+                [synthesizedInfo setObject:@"hiddenDiv" forKey:@"EntitlementsWarning"];
             }
 
             value = [propertyList objectForKey:@"DeveloperCertificates"];

--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -537,10 +537,13 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
             if (codesignEntitlementsData != nil) {
                 // read the entitlements directly from the codesign output
                 NSDictionary *entitlementsPropertyList = [NSPropertyListSerialization propertyListWithData:codesignEntitlementsData options:0 format:NULL error:NULL];
-                NSMutableString *dictionaryFormatted = [NSMutableString string];
-                displayKeyAndValue(0, nil, entitlementsPropertyList, dictionaryFormatted);
-                synthesizedValue = [NSString stringWithFormat:@"<pre>%@</pre>", dictionaryFormatted];
-
+                if (entitlementsPropertyList != nil) {
+                    NSMutableString *dictionaryFormatted = [NSMutableString string];
+                    displayKeyAndValue(0, nil, entitlementsPropertyList, dictionaryFormatted);
+                    synthesizedValue = [NSString stringWithFormat:@"<pre>%@</pre>", dictionaryFormatted];
+                } else {
+                    synthesizedValue = @"Entitlements extraction failed.";
+                }
                 [synthesizedInfo setObject:synthesizedValue forKey:@"EntitlementsFormatted"];
             } else {
                 // read the entitlements from the provisioning profile instead

--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -247,11 +247,11 @@ NSData *codesignEntitlementsDataFromApp(NSData *infoPlistData, NSString *basePat
     NSString *bundleExecutable = [appPropertyList objectForKey:@"CFBundleExecutable"];
 
     NSString *binaryPath = [basePath stringByAppendingPathComponent:bundleExecutable];
-    // get entitlements: codesign -d <AppBinary> --entitlements :-
+    // get entitlements: codesign -d <AppBinary> --entitlements - --xml
     NSTask *codesignTask = [NSTask new];
     [codesignTask setLaunchPath:@"/usr/bin/codesign"];
     [codesignTask setStandardOutput:[NSPipe pipe]];
-    [codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @":-"]];
+    [codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @"-", @"--xml"]];
     [codesignTask launch];
 
     NSData *pipeData = [[[codesignTask standardOutput] fileHandleForReading] readDataToEndOfFile];

--- a/ProvisionQL/Resources/template.html
+++ b/ProvisionQL/Resources/template.html
@@ -144,7 +144,7 @@
 				Name: <strong>__CFBundleName__</strong><br />
 				Version: __CFBundleShortVersionString__ (__CFBundleVersion__)<br />
 				BundleId: __CFBundleIdentifier__<br />
-                <div class="extension __ExtensionInfo__">
+                <div class="__ExtensionInfo__">
                     Extension type: __NSExtensionPointIdentifier__<br />
                 </div>
 				DeviceFamily: __UIDeviceFamily__<br />
@@ -156,7 +156,7 @@
             __AppTransportSecurityFormatted__
         </div>
 
-        <div class="provision __ProvisionInfo__">
+        <div class="__ProvisionInfo__">
             <div class="__AppInfo__">
                 <h1>Provisioning</h1>
                 Profile name: <strong>__Name__</strong><br />
@@ -184,7 +184,7 @@
             __ProvisionedDevicesFormatted__
 
 		</div>
-        <div class="fileInfo">
+        <div>
             <h2>File info</h2>
             __FileName__<br />
             __FileInfo__<br />

--- a/ProvisionQL/Resources/template.html
+++ b/ProvisionQL/Resources/template.html
@@ -61,7 +61,7 @@
                     text-transform: uppercase;
                 }
 
-                .expired {
+                .expired, .warning {
                     color: darkred;
                 }
                 .expiring {
@@ -116,7 +116,7 @@
                     a:hover   { color: #fff; }
                     a:visited { color: #aaa; }
 
-                    .expired {
+                    .expired, .warning {
                         color: red;
                     }
                     .expiring {
@@ -172,6 +172,9 @@
 			Expiration Date: <strong><span class="__ExpStatus__">__ExpirationDateFormatted__ (__ExpirationSummary__)</span></strong><br />
 
             <h2>Entitlements</h2>
+            <div class="__EntitlementsWarning__ warning">
+                <strong>Entitlements extraction failed.</strong>
+            </div>
             __EntitlementsFormatted__
 
 			<h2>Developer Certificates</h2>


### PR DESCRIPTION
## Description

While investigating report  https://github.com/ealeksandrov/ProvisionQL/issues/46 I found that `codesign` can error on entitlements extraction from the binary. In that case "null" will appear in the report because ProvisionQL gets empty output and fails to parse it.

## Changes

- updated `codesign` task to remove deprecated option (replaced `:-` with `- --xml`)
- added error handling to entitlements plist
- added error redirect from `codesign` task
