### PR TITLE
Bugfixes and larger AppIcon

### DIFF
--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -10,50 +10,50 @@ void CancelPreviewGeneration(void *thisInterface, QLPreviewRequestRef preview);
  ----------------------------------------------------------------------------- */
 
 void displayKeyAndValue(NSUInteger level, NSString *key, id value, NSMutableString *output) {
-	int indent = (int)(level * 4);
+    int indent = (int)(level * 4);
 
-	if ([value isKindOfClass:[NSDictionary class]]) {
-		if (key) {
-			[output appendFormat:@"%*s%@ = {\n", indent, "", key];
-		} else if (level != 0) {
-			[output appendFormat:@"%*s{\n", indent, ""];
-		}
-		NSDictionary *dictionary = (NSDictionary *)value;
-		NSArray *keys = [[dictionary allKeys] sortedArrayUsingSelector:@selector(compare:)];
-		for (NSString *subKey in keys) {
+    if ([value isKindOfClass:[NSDictionary class]]) {
+        if (key) {
+            [output appendFormat:@"%*s%@ = {\n", indent, "", key];
+        } else if (level != 0) {
+            [output appendFormat:@"%*s{\n", indent, ""];
+        }
+        NSDictionary *dictionary = (NSDictionary *)value;
+        NSArray *keys = [[dictionary allKeys] sortedArrayUsingSelector:@selector(compare:)];
+        for (NSString *subKey in keys) {
             NSUInteger subLevel = (key == nil && level == 0) ? 0 : level + 1;
-			displayKeyAndValue(subLevel, subKey, [dictionary valueForKey:subKey], output);
-		}
+            displayKeyAndValue(subLevel, subKey, [dictionary valueForKey:subKey], output);
+        }
         if (level != 0) {
             [output appendFormat:@"%*s}\n", indent, ""];
         }
-	} else if ([value isKindOfClass:[NSArray class]]) {
-		[output appendFormat:@"%*s%@ = (\n", indent, "", key];
-		NSArray *array = (NSArray *)value;
-		for (id value in array) {
-			displayKeyAndValue(level + 1, nil, value, output);
-		}
-		[output appendFormat:@"%*s)\n", indent, ""];
-	} else if ([value isKindOfClass:[NSData class]]) {
-		NSData *data = (NSData *)value;
-		if (key) {
-			[output appendFormat:@"%*s%@ = %zd bytes of data\n", indent, "", key, [data length]];
-		} else {
-			[output appendFormat:@"%*s%zd bytes of data\n", indent, "", [data length]];
-		}
-	} else {
-		if (key) {
-			[output appendFormat:@"%*s%@ = %@\n", indent, "", key, value];
-		} else {
-			[output appendFormat:@"%*s%@\n", indent, "", value];
-		}
-	}
+    } else if ([value isKindOfClass:[NSArray class]]) {
+        [output appendFormat:@"%*s%@ = (\n", indent, "", key];
+        NSArray *array = (NSArray *)value;
+        for (id value in array) {
+            displayKeyAndValue(level + 1, nil, value, output);
+        }
+        [output appendFormat:@"%*s)\n", indent, ""];
+    } else if ([value isKindOfClass:[NSData class]]) {
+        NSData *data = (NSData *)value;
+        if (key) {
+            [output appendFormat:@"%*s%@ = %zd bytes of data\n", indent, "", key, [data length]];
+        } else {
+            [output appendFormat:@"%*s%zd bytes of data\n", indent, "", [data length]];
+        }
+    } else {
+        if (key) {
+            [output appendFormat:@"%*s%@ = %@\n", indent, "", key, value];
+        } else {
+            [output appendFormat:@"%*s%@\n", indent, "", value];
+        }
+    }
 }
 
 NSString *expirationStringForDateInCalendar(NSDate *date, NSCalendar *calendar) {
-	NSString *result = nil;
+    NSString *result = nil;
 
-	if (date) {
+    if (date) {
         NSDateComponentsFormatter *formatter = [[NSDateComponentsFormatter alloc] init];
         formatter.unitsStyle = NSDateComponentsFormatterUnitsStyleFull;
         formatter.maximumUnitCount = 1;
@@ -82,9 +82,9 @@ NSString *expirationStringForDateInCalendar(NSDate *date, NSCalendar *calendar) 
             }
         }
 
-	}
+    }
 
-	return result;
+    return result;
 }
 
 NSString *formattedStringForCertificates(NSArray *value) {
@@ -252,11 +252,11 @@ NSData *codesignEntitlementsDataFromApp(NSData *infoPlistData, NSString *basePat
     [codesignTask setLaunchPath:@"/usr/bin/codesign"];
     [codesignTask setStandardOutput:[NSPipe pipe]];
     [codesignTask setStandardError:[NSPipe pipe]];
-	if (@available(macOS 11, *)) {
-		[codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @"-", @"--xml"]];
-	} else {
-		[codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @":-"]];
-	}
+    if (@available(macOS 11, *)) {
+        [codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @"-", @"--xml"]];
+    } else {
+        [codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @":-"]];
+    }
     [codesignTask launch];
 
     NSData *outputData = [[[codesignTask standardOutput] fileHandleForReading] readDataToEndOfFile];
@@ -271,21 +271,21 @@ NSData *codesignEntitlementsDataFromApp(NSData *infoPlistData, NSString *basePat
 }
 
 NSString *iconAsBase64(NSImage *appIcon) {
-	if (!appIcon) {
-		NSURL *iconURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"defaultIcon" withExtension:@"png"];
-		appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
-	}
-	appIcon = roundCorners(appIcon);
-	NSData *imageData = [appIcon TIFFRepresentation];
-	NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:imageData];
-	imageData = [imageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
-	return [imageData base64EncodedStringWithOptions:0];
+    if (!appIcon) {
+        NSURL *iconURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"defaultIcon" withExtension:@"png"];
+        appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
+    }
+    appIcon = roundCorners(appIcon);
+    NSData *imageData = [appIcon TIFFRepresentation];
+    NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:imageData];
+    imageData = [imageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
+    return [imageData base64EncodedStringWithOptions:0];
 }
 
 OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options) {
     @autoreleasepool {
         // create temp directory
-		NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSFileManager *fileManager = [NSFileManager defaultManager];
         NSString *tempDirFolder = [NSTemporaryDirectory() stringByAppendingPathComponent:kPluginBundleId];
         NSString *currentTempDirFolder = [tempDirFolder stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
         [fileManager createDirectoryAtPath:currentTempDirFolder withIntermediateDirectories:YES attributes:nil error:nil];
@@ -298,14 +298,14 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
         NSImage *appIcon = nil;
 
         if ([dataType isEqualToString:kDataType_ipa]) {
-			provisionData = unzipFile(URL, @"Payload/*.app/embedded.mobileprovision");
-			appPlist = unzipFile(URL, @"Payload/*.app/Info.plist");
+            provisionData = unzipFile(URL, @"Payload/*.app/embedded.mobileprovision");
+            appPlist = unzipFile(URL, @"Payload/*.app/Info.plist");
 
             // read codesigning entitlements from application binary (extract it first)
             NSDictionary *appPropertyList = [NSPropertyListSerialization propertyListWithData:appPlist options:0 format:NULL error:NULL];
             NSString *bundleExecutable = [appPropertyList objectForKey:@"CFBundleExecutable"];
 
-			unzipFileToDir(URL, currentTempDirFolder, [@"Payload/*.app/" stringByAppendingPathComponent:bundleExecutable]);
+            unzipFileToDir(URL, currentTempDirFolder, [@"Payload/*.app/" stringByAppendingPathComponent:bundleExecutable]);
 
             codesignEntitlementsData = codesignEntitlementsDataFromApp(appPlist, currentTempDirFolder);
 
@@ -355,14 +355,14 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
         }
 
         if (!provisionData) {
-			NSLog(@"No provisionData for %@", URL);
+            NSLog(@"No provisionData for %@", URL);
 
             if (appPlist != nil) {
                 [synthesizedInfo setObject:@"hiddenDiv" forKey:@"ProvisionInfo"];
             } else {
                 return noErr;
             }
-		} else {
+        } else {
             [synthesizedInfo setObject:@"" forKey:@"ProvisionInfo"];
         }
 
@@ -371,9 +371,9 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
         if (appPlist != nil) {
             NSDictionary *appPropertyList = [NSPropertyListSerialization propertyListWithData:appPlist options:0 format:NULL error:NULL];
 
-			NSString *iconName = mainIconNameForApp(appPropertyList);
-			appIcon = imageFromApp(URL, dataType, iconName);
-			[synthesizedInfo setObject:iconAsBase64(appIcon) forKey:@"AppIcon"];
+            NSString *iconName = mainIconNameForApp(appPropertyList);
+            appIcon = imageFromApp(URL, dataType, iconName);
+            [synthesizedInfo setObject:iconAsBase64(appIcon) forKey:@"AppIcon"];
 
             NSString *bundleName = [appPropertyList objectForKey:@"CFBundleDisplayName"];
             if (!bundleName) {
@@ -720,9 +720,9 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
                                      (__bridge NSString *)kQLPreviewPropertyMIMETypeKey : @"text/html" };
 
         QLPreviewRequestSetDataRepresentation(preview, (__bridge CFDataRef)[html dataUsingEncoding:NSUTF8StringEncoding], kUTTypeHTML, (__bridge CFDictionaryRef)properties);
-	}
+    }
 
-	return noErr;
+    return noErr;
 }
 
 void CancelThumbnailGeneration(void *thisInterface, QLThumbnailRequestRef thumbnail) {

--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -359,10 +359,10 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
             if (!bundleName) {
                 bundleName = [appPropertyList objectForKey:@"CFBundleName"];
             }
-            [synthesizedInfo setObject:bundleName forKey:@"CFBundleName"];
-            [synthesizedInfo setObject:[appPropertyList objectForKey:@"CFBundleIdentifier"] forKey:@"CFBundleIdentifier"];
-            [synthesizedInfo setObject:[appPropertyList objectForKey:@"CFBundleShortVersionString"] forKey:@"CFBundleShortVersionString"];
-            [synthesizedInfo setObject:[appPropertyList objectForKey:@"CFBundleVersion"] forKey:@"CFBundleVersion"];
+            [synthesizedInfo setObject:bundleName ?: @"" forKey:@"CFBundleName"];
+            [synthesizedInfo setObject:[appPropertyList objectForKey:@"CFBundleIdentifier"] ?: @"" forKey:@"CFBundleIdentifier"];
+            [synthesizedInfo setObject:[appPropertyList objectForKey:@"CFBundleShortVersionString"] ?: @"" forKey:@"CFBundleShortVersionString"];
+            [synthesizedInfo setObject:[appPropertyList objectForKey:@"CFBundleVersion"] ?: @"" forKey:@"CFBundleVersion"];
 
             NSString *extensionType = [[appPropertyList objectForKey:@"NSExtension"] objectForKey:@"NSExtensionPointIdentifier"];
             if(extensionType != nil) {
@@ -699,10 +699,10 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
 #endif
 
         synthesizedValue = [[NSBundle bundleWithIdentifier:kPluginBundleId] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-        [synthesizedInfo setObject:synthesizedValue forKey:@"BundleShortVersionString"];
+        [synthesizedInfo setObject:synthesizedValue ?: @"" forKey:@"BundleShortVersionString"];
 
         synthesizedValue = [[NSBundle bundleWithIdentifier:kPluginBundleId] objectForInfoDictionaryKey:@"CFBundleVersion"];
-        [synthesizedInfo setObject:synthesizedValue forKey:@"BundleVersion"];
+        [synthesizedInfo setObject:synthesizedValue ?: @"" forKey:@"BundleVersion"];
 
         for (NSString *key in [synthesizedInfo allKeys]) {
             NSString *replacementValue = [synthesizedInfo objectForKey:key];

--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -252,7 +252,11 @@ NSData *codesignEntitlementsDataFromApp(NSData *infoPlistData, NSString *basePat
     [codesignTask setLaunchPath:@"/usr/bin/codesign"];
     [codesignTask setStandardOutput:[NSPipe pipe]];
     [codesignTask setStandardError:[NSPipe pipe]];
-    [codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @"-", @"--xml"]];
+	if (@available(macOS 11, *)) {
+		[codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @"-", @"--xml"]];
+	} else {
+		[codesignTask setArguments:@[@"-d", binaryPath, @"--entitlements", @":-"]];
+	}
     [codesignTask launch];
 
     NSData *outputData = [[[codesignTask standardOutput] fileHandleForReading] readDataToEndOfFile];

--- a/ProvisionQL/GenerateThumbnailForURL.m
+++ b/ProvisionQL/GenerateThumbnailForURL.m
@@ -36,6 +36,13 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
         NSUInteger devicesCount = 0;
         int expStatus = 0;
 
+		static const NSString *IconFlavor;
+		if (@available(macOS 10.15, *)) {
+			IconFlavor = @"icon";
+		} else {
+			IconFlavor = @"IconFlavor";
+		}
+
         if ([dataType isEqualToString:kDataType_xcode_archive]) {
             // get the embedded plist for the iOS app
             NSURL *appsDir = [URL URLByAppendingPathComponent:@"Products/Applications/"];
@@ -68,9 +75,11 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
             }
             appIcon = roundCorners(appIcon);
             if ([dataType isEqualToString:kDataType_xcode_archive]) {
-                propertiesDict = @{@"IconFlavor" : @(12)};
+                // 0: Plain transparent, 1: Shadow, 2: Book, 3: Movie, 4: Address, 5: Image,
+                // 6: Gloss, 7: Slide, 8: Square, 9: Border, 11: Calendar, 12: Pattern
+                propertiesDict = @{IconFlavor : @(12)};
             } else {
-                propertiesDict = @{@"IconFlavor" : @(0)};
+                propertiesDict = @{IconFlavor : @(0)};
             }
         } else {
             if (iconMode) {

--- a/ProvisionQL/GenerateThumbnailForURL.m
+++ b/ProvisionQL/GenerateThumbnailForURL.m
@@ -28,20 +28,8 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
     @autoreleasepool {
         NSURL *URL = (__bridge NSURL *)url;
         NSString *dataType = (__bridge NSString *)contentTypeUTI;
-        NSDictionary *optionsDict = (__bridge NSDictionary *)options;
-        BOOL iconMode = ([optionsDict objectForKey:(NSString *)kQLThumbnailOptionIconModeKey]) ? YES : NO;
-        NSData *provisionData = nil;
         NSData *appPlist = nil;
         NSImage *appIcon = nil;
-        NSUInteger devicesCount = 0;
-        int expStatus = 0;
-
-		static const NSString *IconFlavor;
-		if (@available(macOS 10.15, *)) {
-			IconFlavor = @"icon";
-		} else {
-			IconFlavor = @"IconFlavor";
-		}
 
         if ([dataType isEqualToString:kDataType_xcode_archive]) {
             // get the embedded plist for the iOS app
@@ -54,26 +42,34 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
             }
         } else if([dataType isEqualToString:kDataType_ipa]) {
 			appPlist = unzipFile(URL, @"Payload/*.app/Info.plist");
-        } else {
-            // use provisioning directly
-            provisionData = [NSData dataWithContentsOfURL:URL];
         }
 
         if (QLThumbnailRequestIsCancelled(thumbnail)) {
             return noErr;
         }
 
-        NSDictionary *propertiesDict = nil;
+		// MARK: .ipa & .xarchive
+
         if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
             NSDictionary *appPropertyList = [NSPropertyListSerialization propertyListWithData:appPlist options:0 format:NULL error:NULL];
             NSString *iconName = mainIconNameForApp(appPropertyList);
             appIcon = imageFromApp(URL, dataType, iconName);
 
+			if (QLThumbnailRequestIsCancelled(thumbnail)) {
+				return noErr;
+			}
+
             if (!appIcon) {
                 NSURL *iconURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"defaultIcon" withExtension:@"png"];
                 appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
             }
-            appIcon = roundCorners(appIcon);
+			static const NSString *IconFlavor;
+			if (@available(macOS 10.15, *)) {
+				IconFlavor = @"icon";
+			} else {
+				IconFlavor = @"IconFlavor";
+			}
+            NSDictionary *propertiesDict = nil;
             if ([dataType isEqualToString:kDataType_xcode_archive]) {
                 // 0: Plain transparent, 1: Shadow, 2: Book, 3: Movie, 4: Address, 5: Image,
                 // 6: Gloss, 7: Slide, 8: Square, 9: Border, 11: Calendar, 12: Pattern
@@ -81,108 +77,112 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
             } else {
                 propertiesDict = @{IconFlavor : @(0)};
             }
-        } else {
-            if (iconMode) {
-                NSURL *iconURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"blankIcon" withExtension:@"png"];
-                appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
-            } else {
-                appIcon = [[NSWorkspace sharedWorkspace] iconForFileType:dataType];
-                [appIcon setSize:NSMakeSize(512,512)];
-            }
-
-            if (!provisionData) {
-                NSLog(@"No provisionData for %@", URL);
-                return noErr;
-            }
-
-            CMSDecoderRef decoder = NULL;
-            CMSDecoderCreate(&decoder);
-            CMSDecoderUpdateMessage(decoder, provisionData.bytes, provisionData.length);
-            CMSDecoderFinalizeMessage(decoder);
-            CFDataRef dataRef = NULL;
-            CMSDecoderCopyContent(decoder, &dataRef);
-            NSData *data = (NSData *)CFBridgingRelease(dataRef);
-            CFRelease(decoder);
-
-            if (!data || QLThumbnailRequestIsCancelled(thumbnail)) {
-                return noErr;
-            }
-
-            NSDictionary *propertyList = [NSPropertyListSerialization propertyListWithData:data options:0 format:NULL error:NULL];
-            id value = [propertyList objectForKey:@"ProvisionedDevices"];
-            if ([value isKindOfClass:[NSArray class]]) {
-                devicesCount = [value count];
-            }
-
-            value = [propertyList objectForKey:@"ExpirationDate"];
-            if ([value isKindOfClass:[NSDate class]]) {
-                expStatus = expirationStatus(value, [NSCalendar currentCalendar]);
-            }
-        }
-
-        if (QLThumbnailRequestIsCancelled(thumbnail)) {
-            return noErr;
-        }
-
-		// image-only can be drawn efficiently.
-		if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
+			// image-only icons can be drawn efficiently.
+			appIcon = roundCorners(appIcon);
 			[appIcon setSize:QLThumbnailRequestGetMaximumSize(thumbnail)];
 			QLThumbnailRequestSetImageWithData(thumbnail, (__bridge CFDataRef)[appIcon TIFFRepresentation], (__bridge CFDictionaryRef)propertiesDict);
 			return noErr;
 		}
 
+		// MARK: .provisioning
+
+		// use provisioning directly
+		NSData *provisionData = [NSData dataWithContentsOfURL:URL];
+		if (!provisionData) {
+			NSLog(@"No provisionData for %@", URL);
+			return noErr;
+		}
+
+		NSDictionary *optionsDict = (__bridge NSDictionary *)options;
+		BOOL iconMode = ([optionsDict objectForKey:(NSString *)kQLThumbnailOptionIconModeKey]) ? YES : NO;
+		NSUInteger devicesCount = 0;
+		int expStatus = 0;
+
+		if (iconMode) {
+			NSURL *iconURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"blankIcon" withExtension:@"png"];
+			appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
+		} else {
+			appIcon = [[NSWorkspace sharedWorkspace] iconForFileType:dataType];
+			[appIcon setSize:NSMakeSize(512,512)];
+		}
+
+		CMSDecoderRef decoder = NULL;
+		CMSDecoderCreate(&decoder);
+		CMSDecoderUpdateMessage(decoder, provisionData.bytes, provisionData.length);
+		CMSDecoderFinalizeMessage(decoder);
+		CFDataRef dataRef = NULL;
+		CMSDecoderCopyContent(decoder, &dataRef);
+		NSData *data = (NSData *)CFBridgingRelease(dataRef);
+		CFRelease(decoder);
+
+		if (!data || QLThumbnailRequestIsCancelled(thumbnail)) {
+			return noErr;
+		}
+
+		NSDictionary *propertyList = [NSPropertyListSerialization propertyListWithData:data options:0 format:NULL error:NULL];
+		id value = [propertyList objectForKey:@"ProvisionedDevices"];
+		if ([value isKindOfClass:[NSArray class]]) {
+			devicesCount = [value count];
+		}
+
+		value = [propertyList objectForKey:@"ExpirationDate"];
+		if ([value isKindOfClass:[NSDate class]]) {
+			expStatus = expirationStatus(value, [NSCalendar currentCalendar]);
+		}
+
+        if (QLThumbnailRequestIsCancelled(thumbnail)) {
+            return noErr;
+        }
+
         NSSize canvasSize = appIcon.size;
         NSRect renderRect = NSMakeRect(0.0, 0.0, appIcon.size.width, appIcon.size.height);
 
-        CGContextRef _context = QLThumbnailRequestCreateContext(thumbnail, canvasSize, false, (__bridge CFDictionaryRef)propertiesDict);
+        CGContextRef _context = QLThumbnailRequestCreateContext(thumbnail, canvasSize, false, NULL);
         if (_context) {
             NSGraphicsContext *_graphicsContext = [NSGraphicsContext graphicsContextWithCGContext:(void *)_context flipped:NO];
 
             [NSGraphicsContext setCurrentContext:_graphicsContext];
-            if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
-                // handled above
-            } else {
-                [appIcon drawInRect:renderRect];
 
-                NSString *badge = [NSString stringWithFormat:@"%lu",(unsigned long)devicesCount];
-                NSColor *outlineColor;
+			[appIcon drawInRect:renderRect];
 
-                if (expStatus == 2) {
-                    outlineColor = BADGE_VALID_COLOR;
-                } else if (expStatus == 1) {
-                    outlineColor = BADGE_EXPIRING_COLOR;
-                } else {
-                    outlineColor = BADGE_EXPIRED_COLOR;
-                }
+			NSString *badge = [NSString stringWithFormat:@"%lu",(unsigned long)devicesCount];
+			NSColor *outlineColor;
 
-                NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
-                paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
-                paragraphStyle.alignment = NSTextAlignmentCenter;
+			if (expStatus == 2) {
+				outlineColor = BADGE_VALID_COLOR;
+			} else if (expStatus == 1) {
+				outlineColor = BADGE_EXPIRING_COLOR;
+			} else {
+				outlineColor = BADGE_EXPIRED_COLOR;
+			}
 
-                NSDictionary *attrDict = @{NSFontAttributeName : BADGE_FONT, NSForegroundColorAttributeName : outlineColor, NSParagraphStyleAttributeName: paragraphStyle};
+			NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+			paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
+			paragraphStyle.alignment = NSTextAlignmentCenter;
 
-                NSSize badgeNumSize = [badge sizeWithAttributes:attrDict];
-                int badgeWidth = badgeNumSize.width + BADGE_MARGIN * 2;
-                badgeWidth = MAX(badgeWidth, MIN_BADGE_WIDTH);
+			NSDictionary *attrDict = @{NSFontAttributeName : BADGE_FONT, NSForegroundColorAttributeName : outlineColor, NSParagraphStyleAttributeName: paragraphStyle};
 
-                int badgeX = renderRect.origin.x + BADGE_MARGIN_X;
-                int badgeY = renderRect.origin.y + renderRect.size.height - BADGE_HEIGHT - BADGE_MARGIN_Y;
-                if (!iconMode) {
-                    badgeX += 75;
-                    badgeY -= 10;
-                }
-                int badgeNumX = badgeX + BADGE_MARGIN;
-                NSRect badgeRect = NSMakeRect(badgeX, badgeY, badgeWidth, BADGE_HEIGHT);
+			NSSize badgeNumSize = [badge sizeWithAttributes:attrDict];
+			int badgeWidth = badgeNumSize.width + BADGE_MARGIN * 2;
+			badgeWidth = MAX(badgeWidth, MIN_BADGE_WIDTH);
 
-                NSBezierPath *badgePath = [NSBezierPath bezierPathWithRoundedRect:badgeRect xRadius:10 yRadius:10];
-                [badgePath setLineWidth:8.0];
-                [BADGE_BG_COLOR set];
-                [badgePath fill];
-                [outlineColor set];
-                [badgePath stroke];
+			int badgeX = renderRect.origin.x + BADGE_MARGIN_X;
+			int badgeY = renderRect.origin.y + renderRect.size.height - BADGE_HEIGHT - BADGE_MARGIN_Y;
+			if (!iconMode) {
+				badgeX += 75;
+				badgeY -= 10;
+			}
+			int badgeNumX = badgeX + BADGE_MARGIN;
+			NSRect badgeRect = NSMakeRect(badgeX, badgeY, badgeWidth, BADGE_HEIGHT);
 
-                [badge drawAtPoint:NSMakePoint(badgeNumX,badgeY) withAttributes:attrDict];
-            }
+			NSBezierPath *badgePath = [NSBezierPath bezierPathWithRoundedRect:badgeRect xRadius:10 yRadius:10];
+			[badgePath setLineWidth:8.0];
+			[BADGE_BG_COLOR set];
+			[badgePath fill];
+			[outlineColor set];
+			[badgePath stroke];
+
+			[badge drawAtPoint:NSMakePoint(badgeNumX,badgeY) withAttributes:attrDict];
 
             QLThumbnailRequestFlushContext(thumbnail, _context);
             CFRelease(_context);

--- a/ProvisionQL/GenerateThumbnailForURL.m
+++ b/ProvisionQL/GenerateThumbnailForURL.m
@@ -79,7 +79,10 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
             }
 			// image-only icons can be drawn efficiently.
 			appIcon = roundCorners(appIcon);
-			[appIcon setSize:QLThumbnailRequestGetMaximumSize(thumbnail)];
+			// downscale as required by QLThumbnailRequestSetImageWithData
+			if (appIcon.size.width > maxSize.width && appIcon.size.height > maxSize.height) {
+				[appIcon setSize:maxSize];
+			}
 			QLThumbnailRequestSetImageWithData(thumbnail, (__bridge CFDataRef)[appIcon TIFFRepresentation], (__bridge CFDictionaryRef)propertiesDict);
 			return noErr;
 		}

--- a/ProvisionQL/GenerateThumbnailForURL.m
+++ b/ProvisionQL/GenerateThumbnailForURL.m
@@ -124,6 +124,13 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
             return noErr;
         }
 
+		// image-only can be drawn efficiently.
+		if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
+			[appIcon setSize:QLThumbnailRequestGetMaximumSize(thumbnail)];
+			QLThumbnailRequestSetImageWithData(thumbnail, (__bridge CFDataRef)[appIcon TIFFRepresentation], (__bridge CFDictionaryRef)propertiesDict);
+			return noErr;
+		}
+
         NSSize canvasSize = appIcon.size;
         NSRect renderRect = NSMakeRect(0.0, 0.0, appIcon.size.width, appIcon.size.height);
 
@@ -133,7 +140,7 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
 
             [NSGraphicsContext setCurrentContext:_graphicsContext];
             if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
-                [appIcon drawInRect:renderRect];
+                // handled above
             } else {
                 [appIcon drawInRect:renderRect];
 

--- a/ProvisionQL/GenerateThumbnailForURL.m
+++ b/ProvisionQL/GenerateThumbnailForURL.m
@@ -46,17 +46,7 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
                 }
             }
         } else if([dataType isEqualToString:kDataType_ipa]) {
-            // get the embedded plist from an app archive using: unzip -p <URL> 'Payload/*.app/Info.plist' (piped to standard output)
-            NSTask *unzipTask = [NSTask new];
-            [unzipTask setLaunchPath:@"/usr/bin/unzip"];
-            [unzipTask setStandardOutput:[NSPipe pipe]];
-            [unzipTask setArguments:@[@"-p", [URL path], @"Payload/*.app/Info.plist", @"-x", @"*/*/*/*"]];
-            [unzipTask launch];
-
-            NSData *pipeData = [[[unzipTask standardOutput] fileHandleForReading] readDataToEndOfFile];
-            [unzipTask waitUntilExit];
-
-            appPlist = pipeData;
+			appPlist = unzipFile(URL, @"Payload/*.app/Info.plist");
         } else {
             // use provisioning directly
             provisionData = [NSData dataWithContentsOfURL:URL];

--- a/ProvisionQL/GenerateThumbnailForURL.m
+++ b/ProvisionQL/GenerateThumbnailForURL.m
@@ -79,10 +79,10 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
             }
 			// image-only icons can be drawn efficiently.
 			appIcon = roundCorners(appIcon);
-			// downscale as required by QLThumbnailRequestSetImageWithData
-			if (appIcon.size.width > maxSize.width && appIcon.size.height > maxSize.height) {
-				[appIcon setSize:maxSize];
-			}
+			// if downscale, then this should respect retina resolution
+//			if (appIcon.size.width > maxSize.width && appIcon.size.height > maxSize.height) {
+//				[appIcon setSize:maxSize];
+//			}
 			QLThumbnailRequestSetImageWithData(thumbnail, (__bridge CFDataRef)[appIcon TIFFRepresentation], (__bridge CFDictionaryRef)propertiesDict);
 			return noErr;
 		}

--- a/ProvisionQL/Resources/template.html
+++ b/ProvisionQL/Resources/template.html
@@ -23,7 +23,7 @@
                 .app img {
                     -webkit-filter: drop-shadow(0px 0px 3px rgba(0,0,0,0.5));
                     filter: drop-shadow(0px 0px 3px rgba(0,0,0,0.5));
-                    max-width: 60px;
+                    width: 100px;
                 }
 
                 .info .subsection {

--- a/ProvisionQL/Shared.h
+++ b/ProvisionQL/Shared.h
@@ -16,6 +16,9 @@ static NSString * const kDataType_osx_provision     = @"com.apple.provisionprofi
 static NSString * const kDataType_xcode_archive     = @"com.apple.xcode.archive";
 static NSString * const kDataType_app_extension     = @"com.apple.application-and-system-extension";
 
+NSData *unzipFile(NSURL *url, NSString *filePath);
+void unzipFileToDir(NSURL *url, NSString *filePath, NSString *targetDir);
+
 NSImage *roundCorners(NSImage *image);
 NSImage *imageFromApp(NSURL *URL, NSString *dataType, NSString *fileName);
 NSString *mainIconNameForApp(NSDictionary *appPropertyList);

--- a/ProvisionQL/Shared.m
+++ b/ProvisionQL/Shared.m
@@ -90,7 +90,10 @@ NSImage *imageFromApp(NSURL *URL, NSString *dataType, NSString *fileName) {
         NSURL *appIconFullURL = [appURL URLByAppendingPathComponent:appIconFullName];
         appIcon = [[NSImage alloc] initWithContentsOfURL:appIconFullURL];
     } else if([dataType isEqualToString:kDataType_ipa]) {
-		NSData *data = unzipFile(URL, [NSString stringWithFormat:@"Payload/*.app/%@*", fileName]);
+		NSData *data = unzipFile(URL, @"iTunesArtwork");
+		if (!data && fileName.length > 0) {
+			data = unzipFile(URL, [NSString stringWithFormat:@"Payload/*.app/%@*", fileName]);
+		}
 		if (data != nil) {
 			appIcon = [[NSImage alloc] initWithData:data];
 		}

--- a/ProvisionQL/Shared.m
+++ b/ProvisionQL/Shared.m
@@ -1,5 +1,28 @@
 #import "Shared.h"
 
+NSData *unzipFile(NSURL *url, NSString *filePath) {
+	NSTask *task = [NSTask new];
+	[task setLaunchPath:@"/usr/bin/unzip"];
+	[task setStandardOutput:[NSPipe pipe]];
+	[task setArguments:@[@"-p", [url path], filePath]]; // @"-x", @"*/*/*/*"
+	[task launch];
+
+	NSData *pipeData = [[[task standardOutput] fileHandleForReading] readDataToEndOfFile];
+	[task waitUntilExit];
+	if (pipeData.length == 0) {
+		return nil;
+	}
+	return pipeData;
+}
+
+void unzipFileToDir(NSURL *url, NSString *targetDir, NSString *filePath) {
+	NSTask *task = [NSTask new];
+	[task setLaunchPath:@"/usr/bin/unzip"];
+	[task setArguments:@[@"-u", @"-j", @"-d", targetDir, [url path], filePath]]; // @"-x", @"*/*/*/*"
+	[task launch];
+	[task waitUntilExit];
+}
+
 NSImage *roundCorners(NSImage *image) {
     NSImage *existingImage = image;
     NSSize existingSize = [existingImage size];
@@ -67,17 +90,10 @@ NSImage *imageFromApp(NSURL *URL, NSString *dataType, NSString *fileName) {
         NSURL *appIconFullURL = [appURL URLByAppendingPathComponent:appIconFullName];
         appIcon = [[NSImage alloc] initWithContentsOfURL:appIconFullURL];
     } else if([dataType isEqualToString:kDataType_ipa]) {
-        // get the embedded icon from an app arcive using: unzip -p <URL> 'Payload/*.app/<fileName>' (piped to standard output)
-        NSTask *unzipTask = [NSTask new];
-        [unzipTask setLaunchPath:@"/usr/bin/unzip"];
-        [unzipTask setStandardOutput:[NSPipe pipe]];
-        [unzipTask setArguments:@[@"-p", [URL path], [NSString stringWithFormat:@"Payload/*.app/%@*", fileName], @"-x", @"*/*/*/*"]];
-        [unzipTask launch];
-
-        NSData *pipeData = [[[unzipTask standardOutput] fileHandleForReading] readDataToEndOfFile];
-        [unzipTask waitUntilExit];
-
-        appIcon = [[NSImage alloc] initWithData:pipeData];
+		NSData *data = unzipFile(URL, [NSString stringWithFormat:@"Payload/*.app/%@*", fileName]);
+		if (data != nil) {
+			appIcon = [[NSImage alloc] initWithData:data];
+		}
     }
 
     return appIcon;

--- a/ProvisionQL/Shared.m
+++ b/ProvisionQL/Shared.m
@@ -1,26 +1,26 @@
 #import "Shared.h"
 
 NSData *unzipFile(NSURL *url, NSString *filePath) {
-	NSTask *task = [NSTask new];
-	[task setLaunchPath:@"/usr/bin/unzip"];
-	[task setStandardOutput:[NSPipe pipe]];
-	[task setArguments:@[@"-p", [url path], filePath]]; // @"-x", @"*/*/*/*"
-	[task launch];
+    NSTask *task = [NSTask new];
+    [task setLaunchPath:@"/usr/bin/unzip"];
+    [task setStandardOutput:[NSPipe pipe]];
+    [task setArguments:@[@"-p", [url path], filePath]]; // @"-x", @"*/*/*/*"
+    [task launch];
 
-	NSData *pipeData = [[[task standardOutput] fileHandleForReading] readDataToEndOfFile];
-	[task waitUntilExit];
-	if (pipeData.length == 0) {
-		return nil;
-	}
-	return pipeData;
+    NSData *pipeData = [[[task standardOutput] fileHandleForReading] readDataToEndOfFile];
+    [task waitUntilExit];
+    if (pipeData.length == 0) {
+        return nil;
+    }
+    return pipeData;
 }
 
 void unzipFileToDir(NSURL *url, NSString *targetDir, NSString *filePath) {
-	NSTask *task = [NSTask new];
-	[task setLaunchPath:@"/usr/bin/unzip"];
-	[task setArguments:@[@"-u", @"-j", @"-d", targetDir, [url path], filePath]]; // @"-x", @"*/*/*/*"
-	[task launch];
-	[task waitUntilExit];
+    NSTask *task = [NSTask new];
+    [task setLaunchPath:@"/usr/bin/unzip"];
+    [task setArguments:@[@"-u", @"-j", @"-d", targetDir, [url path], filePath]]; // @"-x", @"*/*/*/*"
+    [task launch];
+    [task waitUntilExit];
 }
 
 NSImage *roundCorners(NSImage *image) {
@@ -44,23 +44,23 @@ NSImage *roundCorners(NSImage *image) {
 }
 
 int expirationStatus(NSDate *date, NSCalendar *calendar) {
-	int result = 0;
+    int result = 0;
 
-	if (date) {
+    if (date) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitDay fromDate:[NSDate date] toDate:date options:0];
         if ([date compare:[NSDate date]] == NSOrderedAscending) {
             // expired
-			result = 0;
-		} else if (dateComponents.day < 30) {
+            result = 0;
+        } else if (dateComponents.day < 30) {
             // expiring
-			result = 1;
-		} else {
+            result = 1;
+        } else {
             // valid
-			result = 2;
-		}
-	}
+            result = 2;
+        }
+    }
 
-	return result;
+    return result;
 }
 
 NSImage *imageFromApp(NSURL *URL, NSString *dataType, NSString *fileName) {
@@ -90,13 +90,13 @@ NSImage *imageFromApp(NSURL *URL, NSString *dataType, NSString *fileName) {
         NSURL *appIconFullURL = [appURL URLByAppendingPathComponent:appIconFullName];
         appIcon = [[NSImage alloc] initWithContentsOfURL:appIconFullURL];
     } else if([dataType isEqualToString:kDataType_ipa]) {
-		NSData *data = unzipFile(URL, @"iTunesArtwork");
-		if (!data && fileName.length > 0) {
-			data = unzipFile(URL, [NSString stringWithFormat:@"Payload/*.app/%@*", fileName]);
-		}
-		if (data != nil) {
-			appIcon = [[NSImage alloc] initWithData:data];
-		}
+        NSData *data = unzipFile(URL, @"iTunesArtwork");
+        if (!data && fileName.length > 0) {
+            data = unzipFile(URL, [NSString stringWithFormat:@"Payload/*.app/%@*", fileName]);
+        }
+        if (data != nil) {
+            appIcon = [[NSImage alloc] initWithData:data];
+        }
     }
 
     return appIcon;


### PR DESCRIPTION
Hi there and thank you for this QL plugin. 
My commits follow semantic naming so it is probably easier to read by commits than by overall changes ;-)

This PR:
- fix codesign on 10.15 has no `--xml` flag. f5facd5dd03d777f72e363321dc1618edeae9acb
- fix crash if Plist key is not present. 2a339fc52e9692067c20cee1a98fd3c9666f519a (in my case `CFBundleShortVersionString` for an iOS 3.2 ipa)
- use higher resolution app icon (iTunesArtwork) if available. 5ddcdc97c9fcc61b1a0e7a9023f8e0d7ed030e83
- slightly larger icon in preview (and fixed-width icons for consistent placement).
- some refactoring to reduce duplicate code

PS: I removed the `@"-x", @"*/*/*/*"` args as I think it is not used for single file unzips anyway? Let me know if this was a mistake. Otherwise the console will always printing the following error:

```
caution: excluded filename not matched:  */*/*/*
```