### PR TITLE
Replace usage of /usr/bin/codesign

### DIFF
--- a/ProvisionQL.xcodeproj/project.pbxproj
+++ b/ProvisionQL.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		55DB728F186E193500CAFEE7 /* GenerateThumbnailForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB728E186E193500CAFEE7 /* GenerateThumbnailForURL.m */; };
 		55DB7291186E193500CAFEE7 /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB7290186E193500CAFEE7 /* GeneratePreviewForURL.m */; };
 		55DB729B186E195500CAFEE7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55DB729A186E195500CAFEE7 /* Security.framework */; };
+		6572FC592CD0616D0013F54D /* NSBundle+ProvisionQL.m in Sources */ = {isa = PBXBuildFile; fileRef = 6572FC582CD0616D0013F54D /* NSBundle+ProvisionQL.m */; };
+		6572FC5A2CD0616D0013F54D /* NSBundle+ProvisionQL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6572FC572CD0616D0013F54D /* NSBundle+ProvisionQL.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -49,6 +51,8 @@
 		55DB728E186E193500CAFEE7 /* GenerateThumbnailForURL.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GenerateThumbnailForURL.m; sourceTree = "<group>"; };
 		55DB7290186E193500CAFEE7 /* GeneratePreviewForURL.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GeneratePreviewForURL.m; sourceTree = "<group>"; };
 		55DB729A186E195500CAFEE7 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		6572FC572CD0616D0013F54D /* NSBundle+ProvisionQL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+ProvisionQL.h"; sourceTree = "<group>"; };
+		6572FC582CD0616D0013F54D /* NSBundle+ProvisionQL.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+ProvisionQL.m"; sourceTree = "<group>"; };
 		AE61B2AE236C969C003749A1 /* autoupdate-revision.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "autoupdate-revision.sh"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -155,6 +159,8 @@
 				555E9511186E2D67001D406A /* Supporting-files */,
 				555E951A186E2DC0001D406A /* Scripts */,
 				555E9518186E2DC0001D406A /* Resources */,
+				6572FC572CD0616D0013F54D /* NSBundle+ProvisionQL.h */,
+				6572FC582CD0616D0013F54D /* NSBundle+ProvisionQL.m */,
 				557C842718733828008A2A0C /* Shared.h */,
 				557C842418732599008A2A0C /* Shared.m */,
 				55DB728E186E193500CAFEE7 /* GenerateThumbnailForURL.m */,
@@ -172,6 +178,7 @@
 			files = (
 				55424C671870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect.h in Headers */,
 				557C842818733828008A2A0C /* Shared.h in Headers */,
+				6572FC5A2CD0616D0013F54D /* NSBundle+ProvisionQL.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -280,6 +287,7 @@
 				55424C681870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect.m in Sources */,
 				555E9515186E2D67001D406A /* main.c in Sources */,
 				557C842618732599008A2A0C /* Shared.m in Sources */,
+				6572FC592CD0616D0013F54D /* NSBundle+ProvisionQL.m in Sources */,
 				55DB728F186E193500CAFEE7 /* GenerateThumbnailForURL.m in Sources */,
 				55DB7291186E193500CAFEE7 /* GeneratePreviewForURL.m in Sources */,
 			);

--- a/ProvisionQL.xcodeproj/project.pbxproj
+++ b/ProvisionQL.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -24,10 +24,61 @@
 		55DB728F186E193500CAFEE7 /* GenerateThumbnailForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB728E186E193500CAFEE7 /* GenerateThumbnailForURL.m */; };
 		55DB7291186E193500CAFEE7 /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB7290186E193500CAFEE7 /* GeneratePreviewForURL.m */; };
 		55DB729B186E195500CAFEE7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55DB729A186E195500CAFEE7 /* Security.framework */; };
+		6563A9092CD38187007D7307 /* ZIPFoundationObjC in Frameworks */ = {isa = PBXBuildFile; productRef = 6563A9082CD38187007D7307 /* ZIPFoundationObjC */; };
+		6563A90B2CD3818B007D7307 /* ZIPFoundationObjC in Frameworks */ = {isa = PBXBuildFile; productRef = 6563A90A2CD3818B007D7307 /* ZIPFoundationObjC */; };
+		6563A90C2CD381AA007D7307 /* Shared.m in Sources */ = {isa = PBXBuildFile; fileRef = 557C842418732599008A2A0C /* Shared.m */; };
+		6563A90D2CD381AA007D7307 /* GenerateThumbnailForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB728E186E193500CAFEE7 /* GenerateThumbnailForURL.m */; };
+		6563A90E2CD381AA007D7307 /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB7290186E193500CAFEE7 /* GeneratePreviewForURL.m */; };
+		6563A90F2CD381AA007D7307 /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB7290186E193500CAFEE7 /* GeneratePreviewForURL.m */; };
+		6563A9102CD381AA007D7307 /* Shared.m in Sources */ = {isa = PBXBuildFile; fileRef = 557C842418732599008A2A0C /* Shared.m */; };
+		6563A9112CD381AA007D7307 /* GenerateThumbnailForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB728E186E193500CAFEE7 /* GenerateThumbnailForURL.m */; };
+		6563A9122CD381B4007D7307 /* NSBezierPath+IOS7RoundedRect.m in Sources */ = {isa = PBXBuildFile; fileRef = 55424C661870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect.m */; };
+		6563A9132CD381B4007D7307 /* NSBezierPath+IOS7RoundedRect.m in Sources */ = {isa = PBXBuildFile; fileRef = 55424C661870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect.m */; };
+		6563A9332CD3B0EF007D7307 /* template.html in Resources */ = {isa = PBXBuildFile; fileRef = 555E9519186E2DC0001D406A /* template.html */; };
+		6563A9342CD3B0FC007D7307 /* defaultIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 55424C621870D90E002F5408 /* defaultIcon.png */; };
+		6563A9352CD3B0FC007D7307 /* defaultIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 55424C621870D90E002F5408 /* defaultIcon.png */; };
+		6563A9362CD3B108007D7307 /* blankIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 553C6D311879E457002237FC /* blankIcon.png */; };
 		6572FC592CD0616D0013F54D /* NSBundle+ProvisionQL.m in Sources */ = {isa = PBXBuildFile; fileRef = 6572FC582CD0616D0013F54D /* NSBundle+ProvisionQL.m */; };
 		6572FC5A2CD0616D0013F54D /* NSBundle+ProvisionQL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6572FC572CD0616D0013F54D /* NSBundle+ProvisionQL.h */; };
 		6599DD902CD37BC200485DD4 /* ZIPFoundationObjC in Frameworks */ = {isa = PBXBuildFile; productRef = 6599DD8F2CD37BC200485DD4 /* ZIPFoundationObjC */; };
+		6599DDC92CD37FD100485DD4 /* QuickLookThumbnailing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6599DDC82CD37FD100485DD4 /* QuickLookThumbnailing.framework */; };
+		6599DDCA2CD37FD100485DD4 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6599DDAD2CD37FB400485DD4 /* Quartz.framework */; };
+		6599DDD32CD37FD100485DD4 /* ProvisionQLThumbnail.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 6599DDC72CD37FD100485DD4 /* ProvisionQLThumbnail.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		6599DDDD2CD37FE700485DD4 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6599DDAD2CD37FB400485DD4 /* Quartz.framework */; };
+		6599DDEC2CD37FE700485DD4 /* ProvisionQLPreview.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 6599DDDC2CD37FE700485DD4 /* ProvisionQLPreview.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6599DDD12CD37FD100485DD4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 55DB7273186E193500CAFEE7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6599DDC62CD37FD100485DD4;
+			remoteInfo = ProvisionQLThumbnail;
+		};
+		6599DDEA2CD37FE700485DD4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 55DB7273186E193500CAFEE7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6599DDDB2CD37FE700485DD4;
+			remoteInfo = ProvisionQLPreview;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		6599DDC22CD37FB400485DD4 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				6599DDEC2CD37FE700485DD4 /* ProvisionQLPreview.appex in Embed Foundation Extensions */,
+				6599DDD32CD37FD100485DD4 /* ProvisionQLThumbnail.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		553C6D311879E457002237FC /* blankIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = blankIcon.png; sourceTree = "<group>"; };
@@ -54,8 +105,36 @@
 		55DB729A186E195500CAFEE7 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		6572FC572CD0616D0013F54D /* NSBundle+ProvisionQL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+ProvisionQL.h"; sourceTree = "<group>"; };
 		6572FC582CD0616D0013F54D /* NSBundle+ProvisionQL.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+ProvisionQL.m"; sourceTree = "<group>"; };
+		6599DD952CD37F9800485DD4 /* ProvisionQLApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProvisionQLApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6599DDAD2CD37FB400485DD4 /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
+		6599DDC72CD37FD100485DD4 /* ProvisionQLThumbnail.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ProvisionQLThumbnail.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		6599DDC82CD37FD100485DD4 /* QuickLookThumbnailing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLookThumbnailing.framework; path = System/Library/Frameworks/QuickLookThumbnailing.framework; sourceTree = SDKROOT; };
+		6599DDDC2CD37FE700485DD4 /* ProvisionQLPreview.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ProvisionQLPreview.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE61B2AE236C969C003749A1 /* autoupdate-revision.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "autoupdate-revision.sh"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		6599DDD42CD37FD100485DD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 6599DDC62CD37FD100485DD4 /* ProvisionQLThumbnail */;
+		};
+		6599DDED2CD37FE700485DD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 6599DDDB2CD37FE700485DD4 /* ProvisionQLPreview */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		6599DD962CD37F9800485DD4 /* ProvisionQLApp */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ProvisionQLApp; sourceTree = "<group>"; };
+		6599DDCB2CD37FD100485DD4 /* ProvisionQLThumbnail */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (6599DDD42CD37FD100485DD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ProvisionQLThumbnail; sourceTree = "<group>"; };
+		6599DDDE2CD37FE700485DD4 /* ProvisionQLPreview */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (6599DDED2CD37FE700485DD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ProvisionQLPreview; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		55DB7278186E193500CAFEE7 /* Frameworks */ = {
@@ -70,6 +149,32 @@
 				55DB7281186E193500CAFEE7 /* QuickLook.framework in Frameworks */,
 				55DB7285186E193500CAFEE7 /* CoreServices.framework in Frameworks */,
 				55DB7283186E193500CAFEE7 /* ApplicationServices.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6599DD922CD37F9800485DD4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6599DDC42CD37FD100485DD4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6599DDC92CD37FD100485DD4 /* QuickLookThumbnailing.framework in Frameworks */,
+				6563A90B2CD3818B007D7307 /* ZIPFoundationObjC in Frameworks */,
+				6599DDCA2CD37FD100485DD4 /* Quartz.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6599DDD92CD37FE700485DD4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6599DDDD2CD37FE700485DD4 /* Quartz.framework in Frameworks */,
+				6563A9092CD38187007D7307 /* ZIPFoundationObjC in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,6 +233,9 @@
 				55457C10203C4A7500ED02E5 /* Metadata */,
 				55424C641870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect */,
 				55DB7288186E193500CAFEE7 /* ProvisionQL */,
+				6599DD962CD37F9800485DD4 /* ProvisionQLApp */,
+				6599DDCB2CD37FD100485DD4 /* ProvisionQLThumbnail */,
+				6599DDDE2CD37FE700485DD4 /* ProvisionQLPreview */,
 				55DB727F186E193500CAFEE7 /* Frameworks */,
 				55DB727E186E193500CAFEE7 /* Products */,
 			);
@@ -137,6 +245,9 @@
 			isa = PBXGroup;
 			children = (
 				55DB727D186E193500CAFEE7 /* ProvisionQL.qlgenerator */,
+				6599DD952CD37F9800485DD4 /* ProvisionQLApp.app */,
+				6599DDC72CD37FD100485DD4 /* ProvisionQLThumbnail.appex */,
+				6599DDDC2CD37FE700485DD4 /* ProvisionQLPreview.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -151,6 +262,8 @@
 				55DB7282186E193500CAFEE7 /* ApplicationServices.framework */,
 				55DB7284186E193500CAFEE7 /* CoreServices.framework */,
 				55DB7286186E193500CAFEE7 /* CoreFoundation.framework */,
+				6599DDAD2CD37FB400485DD4 /* Quartz.framework */,
+				6599DDC82CD37FD100485DD4 /* QuickLookThumbnailing.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -206,6 +319,77 @@
 			productReference = 55DB727D186E193500CAFEE7 /* ProvisionQL.qlgenerator */;
 			productType = "com.apple.product-type.bundle";
 		};
+		6599DD942CD37F9800485DD4 /* ProvisionQLApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6599DDA52CD37F9A00485DD4 /* Build configuration list for PBXNativeTarget "ProvisionQLApp" */;
+			buildPhases = (
+				6599DD912CD37F9800485DD4 /* Sources */,
+				6599DD922CD37F9800485DD4 /* Frameworks */,
+				6599DD932CD37F9800485DD4 /* Resources */,
+				6599DDC22CD37FB400485DD4 /* Embed Foundation Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6599DDD22CD37FD100485DD4 /* PBXTargetDependency */,
+				6599DDEB2CD37FE700485DD4 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				6599DD962CD37F9800485DD4 /* ProvisionQLApp */,
+			);
+			name = ProvisionQLApp;
+			packageProductDependencies = (
+			);
+			productName = ProvisionQLApp;
+			productReference = 6599DD952CD37F9800485DD4 /* ProvisionQLApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6599DDC62CD37FD100485DD4 /* ProvisionQLThumbnail */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6599DDD52CD37FD100485DD4 /* Build configuration list for PBXNativeTarget "ProvisionQLThumbnail" */;
+			buildPhases = (
+				6599DDC32CD37FD100485DD4 /* Sources */,
+				6599DDC42CD37FD100485DD4 /* Frameworks */,
+				6599DDC52CD37FD100485DD4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				6599DDCB2CD37FD100485DD4 /* ProvisionQLThumbnail */,
+			);
+			name = ProvisionQLThumbnail;
+			packageProductDependencies = (
+				6563A90A2CD3818B007D7307 /* ZIPFoundationObjC */,
+			);
+			productName = ProvisionQLThumbnail;
+			productReference = 6599DDC72CD37FD100485DD4 /* ProvisionQLThumbnail.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		6599DDDB2CD37FE700485DD4 /* ProvisionQLPreview */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6599DDEE2CD37FE700485DD4 /* Build configuration list for PBXNativeTarget "ProvisionQLPreview" */;
+			buildPhases = (
+				6599DDD82CD37FE700485DD4 /* Sources */,
+				6599DDD92CD37FE700485DD4 /* Frameworks */,
+				6599DDDA2CD37FE700485DD4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				6599DDDE2CD37FE700485DD4 /* ProvisionQLPreview */,
+			);
+			name = ProvisionQLPreview;
+			packageProductDependencies = (
+				6563A9082CD38187007D7307 /* ZIPFoundationObjC */,
+			);
+			productName = ProvisionQLPreview;
+			productReference = 6599DDDC2CD37FE700485DD4 /* ProvisionQLPreview.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -216,8 +400,16 @@
 				ORGANIZATIONNAME = "Evgeny Aleksandrov";
 				TargetAttributes = {
 					55DB727C186E193500CAFEE7 = {
-						DevelopmentTeam = 5567X9EQ9Q;
 						ProvisioningStyle = Manual;
+					};
+					6599DD942CD37F9800485DD4 = {
+						CreatedOnToolsVersion = 16.1;
+					};
+					6599DDC62CD37FD100485DD4 = {
+						CreatedOnToolsVersion = 16.1;
+					};
+					6599DDDB2CD37FE700485DD4 = {
+						CreatedOnToolsVersion = 16.1;
 					};
 				};
 			};
@@ -238,6 +430,9 @@
 			projectRoot = "";
 			targets = (
 				55DB727C186E193500CAFEE7 /* ProvisionQL */,
+				6599DD942CD37F9800485DD4 /* ProvisionQLApp */,
+				6599DDC62CD37FD100485DD4 /* ProvisionQLThumbnail */,
+				6599DDDB2CD37FE700485DD4 /* ProvisionQLPreview */,
 			);
 		};
 /* End PBXProject section */
@@ -250,6 +445,31 @@
 				553C6D321879E457002237FC /* blankIcon.png in Resources */,
 				55424C631870D90E002F5408 /* defaultIcon.png in Resources */,
 				555E951C186E2DC0001D406A /* template.html in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6599DD932CD37F9800485DD4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6599DDC52CD37FD100485DD4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6563A9342CD3B0FC007D7307 /* defaultIcon.png in Resources */,
+				6563A9362CD3B108007D7307 /* blankIcon.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6599DDDA2CD37FE700485DD4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6563A9352CD3B0FC007D7307 /* defaultIcon.png in Resources */,
+				6563A9332CD3B0EF007D7307 /* template.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -287,7 +507,49 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6599DD912CD37F9800485DD4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6599DDC32CD37FD100485DD4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6563A90C2CD381AA007D7307 /* Shared.m in Sources */,
+				6563A90D2CD381AA007D7307 /* GenerateThumbnailForURL.m in Sources */,
+				6563A90E2CD381AA007D7307 /* GeneratePreviewForURL.m in Sources */,
+				6563A9122CD381B4007D7307 /* NSBezierPath+IOS7RoundedRect.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6599DDD82CD37FE700485DD4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6563A90F2CD381AA007D7307 /* GeneratePreviewForURL.m in Sources */,
+				6563A9102CD381AA007D7307 /* Shared.m in Sources */,
+				6563A9112CD381AA007D7307 /* GenerateThumbnailForURL.m in Sources */,
+				6563A9132CD381B4007D7307 /* NSBezierPath+IOS7RoundedRect.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6599DDD22CD37FD100485DD4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6599DDC62CD37FD100485DD4 /* ProvisionQLThumbnail */;
+			targetProxy = 6599DDD12CD37FD100485DD4 /* PBXContainerItemProxy */;
+		};
+		6599DDEB2CD37FE700485DD4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6599DDDB2CD37FE700485DD4 /* ProvisionQLPreview */;
+			targetProxy = 6599DDEA2CD37FE700485DD4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		55DB7295186E193500CAFEE7 /* Debug */ = {
@@ -390,11 +652,13 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5567X9EQ9Q;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "ProvisionQL/Supporting-files/Info.plist";
 				INSTALL_PATH = /Library/QuickLook;
@@ -411,11 +675,13 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5567X9EQ9Q;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "ProvisionQL/Supporting-files/Info.plist";
 				INSTALL_PATH = /Library/QuickLook;
@@ -424,6 +690,248 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ealeksandrov.ProvisionQL;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = qlgenerator;
+			};
+			name = Release;
+		};
+		6599DDA62CD37F9A00485DD4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = ProvisionQLApp/ProvisionQLApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Evgeny Aleksandrov. All rights reserved.";
+				INFOPLIST_KEY_NSMainStoryboardFile = Main;
+				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ealeksandrov.ProvisionQLApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Debug;
+		};
+		6599DDA72CD37F9A00485DD4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = ProvisionQLApp/ProvisionQLApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Evgeny Aleksandrov. All rights reserved.";
+				INFOPLIST_KEY_NSMainStoryboardFile = Main;
+				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ealeksandrov.ProvisionQLApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Release;
+		};
+		6599DDD62CD37FD100485DD4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = ProvisionQLThumbnail/ProvisionQLThumbnail.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ProvisionQLThumbnail/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ProvisionQLThumbnail;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Evgeny Aleksandrov. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ealeksandrov.ProvisionQLApp.ProvisionQLThumbnail;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Debug;
+		};
+		6599DDD72CD37FD100485DD4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = ProvisionQLThumbnail/ProvisionQLThumbnail.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ProvisionQLThumbnail/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ProvisionQLThumbnail;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Evgeny Aleksandrov. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ealeksandrov.ProvisionQLApp.ProvisionQLThumbnail;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Release;
+		};
+		6599DDEF2CD37FE700485DD4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = ProvisionQLPreview/ProvisionQLPreview.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ProvisionQLPreview/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ProvisionQLPreview;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Evgeny Aleksandrov. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ealeksandrov.ProvisionQLApp.ProvisionQLPreview;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Debug;
+		};
+		6599DDF02CD37FE700485DD4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = ProvisionQLPreview/ProvisionQLPreview.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ProvisionQLPreview/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ProvisionQLPreview;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Evgeny Aleksandrov. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ealeksandrov.ProvisionQLApp.ProvisionQLPreview;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 			};
 			name = Release;
 		};
@@ -448,6 +956,33 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		6599DDA52CD37F9A00485DD4 /* Build configuration list for PBXNativeTarget "ProvisionQLApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6599DDA62CD37F9A00485DD4 /* Debug */,
+				6599DDA72CD37F9A00485DD4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6599DDD52CD37FD100485DD4 /* Build configuration list for PBXNativeTarget "ProvisionQLThumbnail" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6599DDD62CD37FD100485DD4 /* Debug */,
+				6599DDD72CD37FD100485DD4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6599DDEE2CD37FE700485DD4 /* Build configuration list for PBXNativeTarget "ProvisionQLPreview" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6599DDEF2CD37FE700485DD4 /* Debug */,
+				6599DDF02CD37FE700485DD4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -462,6 +997,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		6563A9082CD38187007D7307 /* ZIPFoundationObjC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6599DD8E2CD37BC200485DD4 /* XCRemoteSwiftPackageReference "ZIPFoundationObjC" */;
+			productName = ZIPFoundationObjC;
+		};
+		6563A90A2CD3818B007D7307 /* ZIPFoundationObjC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6599DD8E2CD37BC200485DD4 /* XCRemoteSwiftPackageReference "ZIPFoundationObjC" */;
+			productName = ZIPFoundationObjC;
+		};
 		6599DD8F2CD37BC200485DD4 /* ZIPFoundationObjC */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6599DD8E2CD37BC200485DD4 /* XCRemoteSwiftPackageReference "ZIPFoundationObjC" */;

--- a/ProvisionQL.xcodeproj/project.pbxproj
+++ b/ProvisionQL.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		55DB729B186E195500CAFEE7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55DB729A186E195500CAFEE7 /* Security.framework */; };
 		6572FC592CD0616D0013F54D /* NSBundle+ProvisionQL.m in Sources */ = {isa = PBXBuildFile; fileRef = 6572FC582CD0616D0013F54D /* NSBundle+ProvisionQL.m */; };
 		6572FC5A2CD0616D0013F54D /* NSBundle+ProvisionQL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6572FC572CD0616D0013F54D /* NSBundle+ProvisionQL.h */; };
+		6599DD902CD37BC200485DD4 /* ZIPFoundationObjC in Frameworks */ = {isa = PBXBuildFile; productRef = 6599DD8F2CD37BC200485DD4 /* ZIPFoundationObjC */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,6 +63,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				557C842218731FB7008A2A0C /* WebKit.framework in Frameworks */,
+				6599DD902CD37BC200485DD4 /* ZIPFoundationObjC in Frameworks */,
 				55424C611870D4AA002F5408 /* AppKit.framework in Frameworks */,
 				55DB729B186E195500CAFEE7 /* Security.framework in Frameworks */,
 				55DB7287186E193500CAFEE7 /* CoreFoundation.framework in Frameworks */,
@@ -193,7 +195,6 @@
 				55DB7278186E193500CAFEE7 /* Frameworks */,
 				55DB7279186E193500CAFEE7 /* Headers */,
 				55DB727A186E193500CAFEE7 /* Resources */,
-				55DB727B186E193500CAFEE7 /* Rez */,
 				554C6385186E258000D9EEDE /* Run Script */,
 			);
 			buildRules = (
@@ -229,6 +230,9 @@
 				Base,
 			);
 			mainGroup = 55DB7272186E193500CAFEE7;
+			packageReferences = (
+				6599DD8E2CD37BC200485DD4 /* XCRemoteSwiftPackageReference "ZIPFoundationObjC" */,
+			);
 			productRefGroup = 55DB727E186E193500CAFEE7 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -250,16 +254,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXRezBuildPhase section */
-		55DB727B186E193500CAFEE7 /* Rez */ = {
-			isa = PBXRezBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXRezBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		554C6385186E258000D9EEDE /* Run Script */ = {
@@ -394,6 +388,7 @@
 		55DB7298186E193500CAFEE7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
@@ -414,6 +409,7 @@
 		55DB7299186E193500CAFEE7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
@@ -453,6 +449,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6599DD8E2CD37BC200485DD4 /* XCRemoteSwiftPackageReference "ZIPFoundationObjC" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/nostradani/ZIPFoundationObjC.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		6599DD8F2CD37BC200485DD4 /* ZIPFoundationObjC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6599DD8E2CD37BC200485DD4 /* XCRemoteSwiftPackageReference "ZIPFoundationObjC" */;
+			productName = ZIPFoundationObjC;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 55DB7273186E193500CAFEE7 /* Project object */;
 }

--- a/ProvisionQL.xcodeproj/project.pbxproj
+++ b/ProvisionQL.xcodeproj/project.pbxproj
@@ -31,7 +31,6 @@
 		6563A90E2CD381AA007D7307 /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB7290186E193500CAFEE7 /* GeneratePreviewForURL.m */; };
 		6563A90F2CD381AA007D7307 /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB7290186E193500CAFEE7 /* GeneratePreviewForURL.m */; };
 		6563A9102CD381AA007D7307 /* Shared.m in Sources */ = {isa = PBXBuildFile; fileRef = 557C842418732599008A2A0C /* Shared.m */; };
-		6563A9112CD381AA007D7307 /* GenerateThumbnailForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DB728E186E193500CAFEE7 /* GenerateThumbnailForURL.m */; };
 		6563A9122CD381B4007D7307 /* NSBezierPath+IOS7RoundedRect.m in Sources */ = {isa = PBXBuildFile; fileRef = 55424C661870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect.m */; };
 		6563A9132CD381B4007D7307 /* NSBezierPath+IOS7RoundedRect.m in Sources */ = {isa = PBXBuildFile; fileRef = 55424C661870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect.m */; };
 		6563A9332CD3B0EF007D7307 /* template.html in Resources */ = {isa = PBXBuildFile; fileRef = 555E9519186E2DC0001D406A /* template.html */; };
@@ -46,6 +45,9 @@
 		6599DDD32CD37FD100485DD4 /* ProvisionQLThumbnail.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 6599DDC72CD37FD100485DD4 /* ProvisionQLThumbnail.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		6599DDDD2CD37FE700485DD4 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6599DDAD2CD37FB400485DD4 /* Quartz.framework */; };
 		6599DDEC2CD37FE700485DD4 /* ProvisionQLPreview.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 6599DDDC2CD37FE700485DD4 /* ProvisionQLPreview.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		65FE31CB2CD439CA00219881 /* ProvisioninProfileThumbnailData.m in Sources */ = {isa = PBXBuildFile; fileRef = 65FE31CA2CD439CA00219881 /* ProvisioninProfileThumbnailData.m */; };
+		65FE31CC2CD439CA00219881 /* ProvisioninProfileThumbnailData.m in Sources */ = {isa = PBXBuildFile; fileRef = 65FE31CA2CD439CA00219881 /* ProvisioninProfileThumbnailData.m */; };
+		65FE31CD2CD439CA00219881 /* ProvisioninProfileThumbnailData.h in Headers */ = {isa = PBXBuildFile; fileRef = 65FE31C92CD439CA00219881 /* ProvisioninProfileThumbnailData.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -110,6 +112,8 @@
 		6599DDC72CD37FD100485DD4 /* ProvisionQLThumbnail.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ProvisionQLThumbnail.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		6599DDC82CD37FD100485DD4 /* QuickLookThumbnailing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLookThumbnailing.framework; path = System/Library/Frameworks/QuickLookThumbnailing.framework; sourceTree = SDKROOT; };
 		6599DDDC2CD37FE700485DD4 /* ProvisionQLPreview.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ProvisionQLPreview.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		65FE31C92CD439CA00219881 /* ProvisioninProfileThumbnailData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProvisioninProfileThumbnailData.h; sourceTree = "<group>"; };
+		65FE31CA2CD439CA00219881 /* ProvisioninProfileThumbnailData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProvisioninProfileThumbnailData.m; sourceTree = "<group>"; };
 		AE61B2AE236C969C003749A1 /* autoupdate-revision.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "autoupdate-revision.sh"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -276,6 +280,8 @@
 				555E9518186E2DC0001D406A /* Resources */,
 				6572FC572CD0616D0013F54D /* NSBundle+ProvisionQL.h */,
 				6572FC582CD0616D0013F54D /* NSBundle+ProvisionQL.m */,
+				65FE31C92CD439CA00219881 /* ProvisioninProfileThumbnailData.h */,
+				65FE31CA2CD439CA00219881 /* ProvisioninProfileThumbnailData.m */,
 				557C842718733828008A2A0C /* Shared.h */,
 				557C842418732599008A2A0C /* Shared.m */,
 				55DB728E186E193500CAFEE7 /* GenerateThumbnailForURL.m */,
@@ -293,6 +299,7 @@
 			files = (
 				55424C671870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect.h in Headers */,
 				557C842818733828008A2A0C /* Shared.h in Headers */,
+				65FE31CD2CD439CA00219881 /* ProvisioninProfileThumbnailData.h in Headers */,
 				6572FC5A2CD0616D0013F54D /* NSBundle+ProvisionQL.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -501,6 +508,7 @@
 				55424C681870DB2A002F5408 /* NSBezierPath+IOS7RoundedRect.m in Sources */,
 				555E9515186E2D67001D406A /* main.c in Sources */,
 				557C842618732599008A2A0C /* Shared.m in Sources */,
+				65FE31CC2CD439CA00219881 /* ProvisioninProfileThumbnailData.m in Sources */,
 				6572FC592CD0616D0013F54D /* NSBundle+ProvisionQL.m in Sources */,
 				55DB728F186E193500CAFEE7 /* GenerateThumbnailForURL.m in Sources */,
 				55DB7291186E193500CAFEE7 /* GeneratePreviewForURL.m in Sources */,
@@ -521,6 +529,7 @@
 				6563A90C2CD381AA007D7307 /* Shared.m in Sources */,
 				6563A90D2CD381AA007D7307 /* GenerateThumbnailForURL.m in Sources */,
 				6563A90E2CD381AA007D7307 /* GeneratePreviewForURL.m in Sources */,
+				65FE31CB2CD439CA00219881 /* ProvisioninProfileThumbnailData.m in Sources */,
 				6563A9122CD381B4007D7307 /* NSBezierPath+IOS7RoundedRect.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -531,7 +540,6 @@
 			files = (
 				6563A90F2CD381AA007D7307 /* GeneratePreviewForURL.m in Sources */,
 				6563A9102CD381AA007D7307 /* Shared.m in Sources */,
-				6563A9112CD381AA007D7307 /* GenerateThumbnailForURL.m in Sources */,
 				6563A9132CD381B4007D7307 /* NSBezierPath+IOS7RoundedRect.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProvisionQL/GeneratePreviewForURL.m
+++ b/ProvisionQL/GeneratePreviewForURL.m
@@ -1,4 +1,5 @@
 #import "Shared.h"
+#import "NSBundle+ProvisionQL.h"
 #import <Security/Security.h>
 
 OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options);
@@ -294,7 +295,7 @@ NSData *codesignEntitlementsDataFromApp(NSData *infoPlistData, NSString *basePat
 
 NSString *iconAsBase64(NSImage *appIcon) {
     if (!appIcon) {
-        NSURL *iconURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"defaultIcon" withExtension:@"png"];
+        NSURL *iconURL = [[NSBundle pluginBundle] URLForResource:@"defaultIcon" withExtension:@"png"];
         appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
     }
     appIcon = roundCorners(appIcon);
@@ -359,7 +360,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
         }
 
         NSMutableDictionary *synthesizedInfo = [NSMutableDictionary dictionary];
-        NSURL *htmlURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"template" withExtension:@"html"];
+        NSURL *htmlURL = [[NSBundle pluginBundle] URLForResource:@"template" withExtension:@"html"];
         NSMutableString *html = [NSMutableString stringWithContentsOfURL:htmlURL encoding:NSUTF8StringEncoding error:NULL];
         NSDateFormatter *dateFormatter = [NSDateFormatter new];
         [dateFormatter setDateStyle:NSDateFormatterMediumStyle];
@@ -725,10 +726,10 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
         [synthesizedInfo setObject:@"" forKey:@"DEBUG"];
 #endif
 
-        synthesizedValue = [[NSBundle bundleWithIdentifier:kPluginBundleId] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+        synthesizedValue = [[NSBundle pluginBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
         [synthesizedInfo setObject:synthesizedValue ?: @"" forKey:@"BundleShortVersionString"];
 
-        synthesizedValue = [[NSBundle bundleWithIdentifier:kPluginBundleId] objectForInfoDictionaryKey:@"CFBundleVersion"];
+        synthesizedValue = [[NSBundle pluginBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
         [synthesizedInfo setObject:synthesizedValue ?: @"" forKey:@"BundleVersion"];
 
         for (NSString *key in [synthesizedInfo allKeys]) {

--- a/ProvisionQL/GenerateThumbnailForURL.m
+++ b/ProvisionQL/GenerateThumbnailForURL.m
@@ -1,5 +1,6 @@
 #import "Shared.h"
 #import "NSBundle+ProvisionQL.h"
+#import "ProvisioninProfileThumbnailData.h"
 
 //Layout constants
 #define BADGE_MARGIN        10.0
@@ -19,6 +20,156 @@
 OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thumbnail, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options, CGSize maxSize);
 void CancelThumbnailGeneration(void *thisInterface, QLThumbnailRequestRef thumbnail);
 
+NSImage* generateThumbnailForArchive(NSURL *URL, NSString *dataType) {
+    NSData *appPlist = nil;
+    NSImage *appIcon = nil;
+
+    if ([dataType isEqualToString:kDataType_xcode_archive]) {
+        // get the embedded plist for the iOS app
+        NSURL *appsDir = [URL URLByAppendingPathComponent:@"Products/Applications/"];
+        if (appsDir != nil) {
+            NSArray *dirFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:appsDir.path error:nil];
+            if (dirFiles.count > 0) {
+                appPlist = [NSData dataWithContentsOfURL:[appsDir URLByAppendingPathComponent:[NSString stringWithFormat:@"%@/Info.plist", dirFiles[0]]]];
+            }
+        }
+    } else if([dataType isEqualToString:kDataType_ipa]) {
+        appPlist = unzipFile(URL, @"Payload/*.app/Info.plist");
+    }
+    
+    NSDictionary *appPropertyList = [NSPropertyListSerialization propertyListWithData:appPlist options:0 format:NULL error:NULL];
+    NSString *iconName = mainIconNameForApp(appPropertyList);
+    appIcon = imageFromApp(URL, dataType, iconName);
+
+    if (!appIcon) {
+        NSURL *iconURL = [[NSBundle pluginBundle] URLForResource:@"defaultIcon" withExtension:@"png"];
+        appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
+    }
+    // image-only icons can be drawn efficiently.
+    appIcon = roundCorners(appIcon);
+    // if downscale, then this should respect retina resolution
+//            if (appIcon.size.width > maxSize.width && appIcon.size.height > maxSize.height) {
+//                [appIcon setSize:maxSize];
+//            }
+    
+    return appIcon;
+}
+
+ProvisioninProfileThumbnailData* generateProvisioningProfileData(NSURL *URL, NSString *dataType, BOOL iconMode) {
+    // use provisioning directly
+    NSData *provisionData = [NSData dataWithContentsOfURL:URL];
+    if (!provisionData) {
+        NSLog(@"No provisionData for %@", URL);
+        return nil;
+    }
+
+    NSUInteger devicesCount = 0;
+    int expStatus = 0;
+
+    NSImage *appIcon;
+    if (iconMode) {
+        NSURL *iconURL = [[NSBundle pluginBundle] URLForResource:@"blankIcon" withExtension:@"png"];
+        appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
+    } else {
+        appIcon = [[NSWorkspace sharedWorkspace] iconForFileType:dataType];
+        [appIcon setSize:NSMakeSize(512,512)];
+    }
+
+    CMSDecoderRef decoder = NULL;
+    CMSDecoderCreate(&decoder);
+    CMSDecoderUpdateMessage(decoder, provisionData.bytes, provisionData.length);
+    CMSDecoderFinalizeMessage(decoder);
+    CFDataRef dataRef = NULL;
+    CMSDecoderCopyContent(decoder, &dataRef);
+    NSData *data = (NSData *)CFBridgingRelease(dataRef);
+    CFRelease(decoder);
+
+    if (!data) {
+        return nil;
+    }
+
+    NSDictionary *propertyList = [NSPropertyListSerialization propertyListWithData:data options:0 format:NULL error:NULL];
+    id value = [propertyList objectForKey:@"ProvisionedDevices"];
+    if ([value isKindOfClass:[NSArray class]]) {
+        devicesCount = [value count];
+    }
+
+    value = [propertyList objectForKey:@"ExpirationDate"];
+    if ([value isKindOfClass:[NSDate class]]) {
+        expStatus = expirationStatus(value, [NSCalendar currentCalendar]);
+    }
+
+    return [[ProvisioninProfileThumbnailData alloc] init];
+}
+
+void drawProvisioningProfileThumbnail(CGContextRef _context, NSImage* appIcon, NSUInteger devicesCount, int expStatus, BOOL iconMode) {
+    NSRect renderRect = NSMakeRect(0.0, 0.0, appIcon.size.width, appIcon.size.height);
+    NSGraphicsContext *_graphicsContext = [NSGraphicsContext graphicsContextWithCGContext:(void *)_context flipped:NO];
+
+    [NSGraphicsContext setCurrentContext:_graphicsContext];
+
+    [appIcon drawInRect:renderRect];
+
+    NSString *badge = [NSString stringWithFormat:@"%lu",(unsigned long)devicesCount];
+    NSColor *outlineColor;
+
+    if (expStatus == 2) {
+        outlineColor = BADGE_VALID_COLOR;
+    } else if (expStatus == 1) {
+        outlineColor = BADGE_EXPIRING_COLOR;
+    } else {
+        outlineColor = BADGE_EXPIRED_COLOR;
+    }
+
+    NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+    paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
+    paragraphStyle.alignment = NSTextAlignmentCenter;
+
+    NSDictionary *attrDict = @{NSFontAttributeName : BADGE_FONT, NSForegroundColorAttributeName : outlineColor, NSParagraphStyleAttributeName: paragraphStyle};
+
+    NSSize badgeNumSize = [badge sizeWithAttributes:attrDict];
+    int badgeWidth = badgeNumSize.width + BADGE_MARGIN * 2;
+    badgeWidth = MAX(badgeWidth, MIN_BADGE_WIDTH);
+
+    int badgeX = renderRect.origin.x + BADGE_MARGIN_X;
+    int badgeY = renderRect.origin.y + renderRect.size.height - BADGE_HEIGHT - BADGE_MARGIN_Y;
+    if (!iconMode) {
+        badgeX += 75;
+        badgeY -= 10;
+    }
+    int badgeNumX = badgeX + BADGE_MARGIN;
+    NSRect badgeRect = NSMakeRect(badgeX, badgeY, badgeWidth, BADGE_HEIGHT);
+
+    NSBezierPath *badgePath = [NSBezierPath bezierPathWithRoundedRect:badgeRect xRadius:10 yRadius:10];
+    [badgePath setLineWidth:8.0];
+    [BADGE_BG_COLOR set];
+    [badgePath fill];
+    [outlineColor set];
+    [badgePath stroke];
+
+    [badge drawAtPoint:NSMakePoint(badgeNumX,badgeY) withAttributes:attrDict];
+}
+
+NSDictionary* generateImageDict(NSString* dataType) {
+    
+    static const NSString *IconFlavor;
+    if (@available(macOS 10.15, *)) {
+        IconFlavor = @"icon";
+    } else {
+        IconFlavor = @"IconFlavor";
+    }
+    NSDictionary *propertiesDict = nil;
+    if ([dataType isEqualToString:kDataType_xcode_archive]) {
+        // 0: Plain transparent, 1: Shadow, 2: Book, 3: Movie, 4: Address, 5: Image,
+        // 6: Gloss, 7: Slide, 8: Square, 9: Border, 11: Calendar, 12: Pattern
+        propertiesDict = @{IconFlavor : @(12)};
+    } else {
+        propertiesDict = @{IconFlavor : @(0)};
+    }
+    
+    return propertiesDict;
+}
+
 /* -----------------------------------------------------------------------------
     Generate a thumbnail for file
 
@@ -26,174 +177,39 @@ void CancelThumbnailGeneration(void *thisInterface, QLThumbnailRequestRef thumbn
    ----------------------------------------------------------------------------- */
 
 OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thumbnail, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options, CGSize maxSize) {
+    OSStatus result = noErr;
+    
     @autoreleasepool {
         NSURL *URL = (__bridge NSURL *)url;
         NSString *dataType = (__bridge NSString *)contentTypeUTI;
-        NSData *appPlist = nil;
-        NSImage *appIcon = nil;
-
-        if ([dataType isEqualToString:kDataType_xcode_archive]) {
-            // get the embedded plist for the iOS app
-            NSURL *appsDir = [URL URLByAppendingPathComponent:@"Products/Applications/"];
-            if (appsDir != nil) {
-                NSArray *dirFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:appsDir.path error:nil];
-                if (dirFiles.count > 0) {
-                    appPlist = [NSData dataWithContentsOfURL:[appsDir URLByAppendingPathComponent:[NSString stringWithFormat:@"%@/Info.plist", dirFiles[0]]]];
+        
+        // MARK: .ipa & .xarchive
+        if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
+            NSImage* appIcon = generateThumbnailForArchive(URL, dataType);
+            NSDictionary *propertiesDict = generateImageDict(dataType);
+            
+            if (appIcon != nil && !QLThumbnailRequestIsCancelled(thumbnail)) {
+                QLThumbnailRequestSetImageWithData(thumbnail, (__bridge CFDataRef)[appIcon TIFFRepresentation], (__bridge CFDictionaryRef)propertiesDict);
+            }
+        }
+        else {
+            // MARK: .provisioning
+            NSDictionary *optionsDict = (__bridge NSDictionary *)options;
+            BOOL iconMode = ([optionsDict objectForKey:(NSString *)kQLThumbnailOptionIconModeKey]) ? YES : NO;
+            
+            ProvisioninProfileThumbnailData *data = generateProvisioningProfileData(URL, dataType, iconMode);
+            if (data != nil && !QLThumbnailRequestIsCancelled(thumbnail)) {
+                CGContextRef _context = QLThumbnailRequestCreateContext(thumbnail, data.appIcon.size, false, NULL);
+                if (_context) {
+                    drawProvisioningProfileThumbnail(_context, data.appIcon, data.devicesCount, data.expStatus, iconMode);
+                    QLThumbnailRequestFlushContext(thumbnail, _context);
+                    CFRelease(_context);
                 }
             }
-        } else if([dataType isEqualToString:kDataType_ipa]) {
-            appPlist = unzipFile(URL, @"Payload/*.app/Info.plist");
-        }
-
-        if (QLThumbnailRequestIsCancelled(thumbnail)) {
-            return noErr;
-        }
-
-        // MARK: .ipa & .xarchive
-
-        if ([dataType isEqualToString:kDataType_ipa] || [dataType isEqualToString:kDataType_xcode_archive]) {
-            NSDictionary *appPropertyList = [NSPropertyListSerialization propertyListWithData:appPlist options:0 format:NULL error:NULL];
-            NSString *iconName = mainIconNameForApp(appPropertyList);
-            appIcon = imageFromApp(URL, dataType, iconName);
-
-            if (QLThumbnailRequestIsCancelled(thumbnail)) {
-                return noErr;
-            }
-
-            if (!appIcon) {
-                NSURL *iconURL = [[NSBundle pluginBundle] URLForResource:@"defaultIcon" withExtension:@"png"];
-                appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
-            }
-            static const NSString *IconFlavor;
-            if (@available(macOS 10.15, *)) {
-                IconFlavor = @"icon";
-            } else {
-                IconFlavor = @"IconFlavor";
-            }
-            NSDictionary *propertiesDict = nil;
-            if ([dataType isEqualToString:kDataType_xcode_archive]) {
-                // 0: Plain transparent, 1: Shadow, 2: Book, 3: Movie, 4: Address, 5: Image,
-                // 6: Gloss, 7: Slide, 8: Square, 9: Border, 11: Calendar, 12: Pattern
-                propertiesDict = @{IconFlavor : @(12)};
-            } else {
-                propertiesDict = @{IconFlavor : @(0)};
-            }
-            // image-only icons can be drawn efficiently.
-            appIcon = roundCorners(appIcon);
-            // if downscale, then this should respect retina resolution
-//            if (appIcon.size.width > maxSize.width && appIcon.size.height > maxSize.height) {
-//                [appIcon setSize:maxSize];
-//            }
-            QLThumbnailRequestSetImageWithData(thumbnail, (__bridge CFDataRef)[appIcon TIFFRepresentation], (__bridge CFDictionaryRef)propertiesDict);
-            return noErr;
-        }
-
-        // MARK: .provisioning
-
-        // use provisioning directly
-        NSData *provisionData = [NSData dataWithContentsOfURL:URL];
-        if (!provisionData) {
-            NSLog(@"No provisionData for %@", URL);
-            return noErr;
-        }
-
-        NSDictionary *optionsDict = (__bridge NSDictionary *)options;
-        BOOL iconMode = ([optionsDict objectForKey:(NSString *)kQLThumbnailOptionIconModeKey]) ? YES : NO;
-        NSUInteger devicesCount = 0;
-        int expStatus = 0;
-
-        if (iconMode) {
-            NSURL *iconURL = [[NSBundle pluginBundle] URLForResource:@"blankIcon" withExtension:@"png"];
-            appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
-        } else {
-            appIcon = [[NSWorkspace sharedWorkspace] iconForFileType:dataType];
-            [appIcon setSize:NSMakeSize(512,512)];
-        }
-
-        CMSDecoderRef decoder = NULL;
-        CMSDecoderCreate(&decoder);
-        CMSDecoderUpdateMessage(decoder, provisionData.bytes, provisionData.length);
-        CMSDecoderFinalizeMessage(decoder);
-        CFDataRef dataRef = NULL;
-        CMSDecoderCopyContent(decoder, &dataRef);
-        NSData *data = (NSData *)CFBridgingRelease(dataRef);
-        CFRelease(decoder);
-
-        if (!data || QLThumbnailRequestIsCancelled(thumbnail)) {
-            return noErr;
-        }
-
-        NSDictionary *propertyList = [NSPropertyListSerialization propertyListWithData:data options:0 format:NULL error:NULL];
-        id value = [propertyList objectForKey:@"ProvisionedDevices"];
-        if ([value isKindOfClass:[NSArray class]]) {
-            devicesCount = [value count];
-        }
-
-        value = [propertyList objectForKey:@"ExpirationDate"];
-        if ([value isKindOfClass:[NSDate class]]) {
-            expStatus = expirationStatus(value, [NSCalendar currentCalendar]);
-        }
-
-        if (QLThumbnailRequestIsCancelled(thumbnail)) {
-            return noErr;
-        }
-
-        NSSize canvasSize = appIcon.size;
-        NSRect renderRect = NSMakeRect(0.0, 0.0, appIcon.size.width, appIcon.size.height);
-
-        CGContextRef _context = QLThumbnailRequestCreateContext(thumbnail, canvasSize, false, NULL);
-        if (_context) {
-            NSGraphicsContext *_graphicsContext = [NSGraphicsContext graphicsContextWithCGContext:(void *)_context flipped:NO];
-
-            [NSGraphicsContext setCurrentContext:_graphicsContext];
-
-            [appIcon drawInRect:renderRect];
-
-            NSString *badge = [NSString stringWithFormat:@"%lu",(unsigned long)devicesCount];
-            NSColor *outlineColor;
-
-            if (expStatus == 2) {
-                outlineColor = BADGE_VALID_COLOR;
-            } else if (expStatus == 1) {
-                outlineColor = BADGE_EXPIRING_COLOR;
-            } else {
-                outlineColor = BADGE_EXPIRED_COLOR;
-            }
-
-            NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
-            paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
-            paragraphStyle.alignment = NSTextAlignmentCenter;
-
-            NSDictionary *attrDict = @{NSFontAttributeName : BADGE_FONT, NSForegroundColorAttributeName : outlineColor, NSParagraphStyleAttributeName: paragraphStyle};
-
-            NSSize badgeNumSize = [badge sizeWithAttributes:attrDict];
-            int badgeWidth = badgeNumSize.width + BADGE_MARGIN * 2;
-            badgeWidth = MAX(badgeWidth, MIN_BADGE_WIDTH);
-
-            int badgeX = renderRect.origin.x + BADGE_MARGIN_X;
-            int badgeY = renderRect.origin.y + renderRect.size.height - BADGE_HEIGHT - BADGE_MARGIN_Y;
-            if (!iconMode) {
-                badgeX += 75;
-                badgeY -= 10;
-            }
-            int badgeNumX = badgeX + BADGE_MARGIN;
-            NSRect badgeRect = NSMakeRect(badgeX, badgeY, badgeWidth, BADGE_HEIGHT);
-
-            NSBezierPath *badgePath = [NSBezierPath bezierPathWithRoundedRect:badgeRect xRadius:10 yRadius:10];
-            [badgePath setLineWidth:8.0];
-            [BADGE_BG_COLOR set];
-            [badgePath fill];
-            [outlineColor set];
-            [badgePath stroke];
-
-            [badge drawAtPoint:NSMakePoint(badgeNumX,badgeY) withAttributes:attrDict];
-
-            QLThumbnailRequestFlushContext(thumbnail, _context);
-            CFRelease(_context);
         }
     }
-
-    return noErr;
+    
+    return result;
 }
 
 void CancelPreviewGeneration(void *thisInterface, QLPreviewRequestRef preview) {

--- a/ProvisionQL/GenerateThumbnailForURL.m
+++ b/ProvisionQL/GenerateThumbnailForURL.m
@@ -1,4 +1,5 @@
 #import "Shared.h"
+#import "NSBundle+ProvisionQL.h"
 
 //Layout constants
 #define BADGE_MARGIN        10.0
@@ -60,7 +61,7 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
             }
 
             if (!appIcon) {
-                NSURL *iconURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"defaultIcon" withExtension:@"png"];
+                NSURL *iconURL = [[NSBundle pluginBundle] URLForResource:@"defaultIcon" withExtension:@"png"];
                 appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
             }
             static const NSString *IconFlavor;
@@ -102,7 +103,7 @@ OSStatus GenerateThumbnailForURL(void *thisInterface, QLThumbnailRequestRef thum
         int expStatus = 0;
 
         if (iconMode) {
-            NSURL *iconURL = [[NSBundle bundleWithIdentifier:kPluginBundleId] URLForResource:@"blankIcon" withExtension:@"png"];
+            NSURL *iconURL = [[NSBundle pluginBundle] URLForResource:@"blankIcon" withExtension:@"png"];
             appIcon = [[NSImage alloc] initWithContentsOfURL:iconURL];
         } else {
             appIcon = [[NSWorkspace sharedWorkspace] iconForFileType:dataType];

--- a/ProvisionQL/NSBundle+ProvisionQL.h
+++ b/ProvisionQL/NSBundle+ProvisionQL.h
@@ -1,0 +1,19 @@
+//
+//  NSBundle+ProvisionQL.h
+//  ProvisionQL
+//
+//  Created by Daniel Muhra on 26.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSBundle (ProvisionQL)
+
++ (NSBundle*) pluginBundle;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ProvisionQL/NSBundle+ProvisionQL.m
+++ b/ProvisionQL/NSBundle+ProvisionQL.m
@@ -1,0 +1,18 @@
+//
+//  NSBundle+ProvisionQL.m
+//  ProvisionQL
+//
+//  Created by Daniel Muhra on 26.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import "NSBundle+ProvisionQL.h"
+#import "Shared.h"
+
+@implementation NSBundle (ProvisionQL)
+
++ (NSBundle*) pluginBundle {
+    return [NSBundle bundleWithIdentifier:kPluginBundleId];
+}
+
+@end

--- a/ProvisionQL/ProvisioninProfileThumbnailData.h
+++ b/ProvisionQL/ProvisioninProfileThumbnailData.h
@@ -1,0 +1,26 @@
+//
+//  ProvisioninProfileThumbnailData.h
+//  ProvisionQL
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ProvisioninProfileThumbnailData : NSObject
+
+@property(nonatomic, strong) NSImage* appIcon;
+@property(nonatomic, assign) NSUInteger devicesCount;
+@property(nonatomic, assign) int expStatus;
+
+- (id) initWithAppIcon:(NSImage*) appIcon
+          devicesCount: (NSUInteger) devicesCount
+             expStatus: (int) expStatus;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ProvisionQL/ProvisioninProfileThumbnailData.m
+++ b/ProvisionQL/ProvisioninProfileThumbnailData.m
@@ -1,0 +1,25 @@
+//
+//  ProvisioninProfileThumbnailData.m
+//  ProvisionQL
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import "ProvisioninProfileThumbnailData.h"
+
+@implementation ProvisioninProfileThumbnailData
+
+- (id)initWithAppIcon:(NSImage *)appIcon devicesCount:(NSUInteger)devicesCount expStatus:(int)expStatus {
+    self = [super init];
+    
+    if (self != nil) {
+        self->_appIcon = appIcon;
+        self->_devicesCount = devicesCount;
+        self->_expStatus = expStatus;
+    }
+    
+    return self;
+}
+
+@end

--- a/ProvisionQL/Shared.h
+++ b/ProvisionQL/Shared.h
@@ -17,7 +17,7 @@ static NSString * const kDataType_xcode_archive     = @"com.apple.xcode.archive"
 static NSString * const kDataType_app_extension     = @"com.apple.application-and-system-extension";
 
 NSData *unzipFile(NSURL *url, NSString *filePath);
-void unzipFileToDir(NSURL *url, NSString *filePath, NSString *targetDir);
+BOOL unzipFileToDir(NSURL *url, NSString *filePath, NSString *targetDir);
 
 NSImage *roundCorners(NSImage *image);
 NSImage *imageFromApp(NSURL *URL, NSString *dataType, NSString *fileName);

--- a/ProvisionQL/Shared.h
+++ b/ProvisionQL/Shared.h
@@ -6,7 +6,7 @@
 #import <Cocoa/Cocoa.h>
 #import <Security/Security.h>
 
-#import <NSBezierPath+IOS7RoundedRect.h>
+#import "NSBezierPath+IOS7RoundedRect.h"
 
 static NSString * const kPluginBundleId = @"com.ealeksandrov.ProvisionQL";
 static NSString * const kDataType_ipa               = @"com.apple.itunes.ipa";

--- a/ProvisionQLApp/AppDelegate.h
+++ b/ProvisionQLApp/AppDelegate.h
@@ -1,0 +1,15 @@
+//
+//  AppDelegate.h
+//  ProvisionQLApp
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+
+
+@end
+

--- a/ProvisionQLApp/AppDelegate.m
+++ b/ProvisionQLApp/AppDelegate.m
@@ -1,0 +1,33 @@
+//
+//  AppDelegate.m
+//  ProvisionQLApp
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+
+@end
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+    // Insert code here to initialize your application
+}
+
+
+- (void)applicationWillTerminate:(NSNotification *)aNotification {
+    // Insert code here to tear down your application
+}
+
+
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
+    return YES;
+}
+
+
+@end

--- a/ProvisionQLApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ProvisionQLApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ProvisionQLApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ProvisionQLApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ProvisionQLApp/Assets.xcassets/Contents.json
+++ b/ProvisionQLApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ProvisionQLApp/Base.lproj/Main.storyboard
+++ b/ProvisionQLApp/Base.lproj/Main.storyboard
@@ -1,0 +1,717 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11134" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11134"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="ProvisionQLApp" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="ProvisionQLApp" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About ProvisionQLApp" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide ProvisionQLApp" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit ProvisionQLApp" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq">
+                                                        <connections>
+                                                            <action selector="orderFrontFontPanel:" target="YLy-65-1bz" id="WHr-nq-2xA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27">
+                                                        <connections>
+                                                            <action selector="addFontTrait:" target="YLy-65-1bz" id="hqk-hr-sYV"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq">
+                                                        <connections>
+                                                            <action selector="addFontTrait:" target="YLy-65-1bz" id="IHV-OB-c03"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL">
+                                                        <connections>
+                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="Uc7-di-UnL"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST">
+                                                        <connections>
+                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="HcX-Lf-eNd"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                                        <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="ProvisionQLApp Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider=""/>
+                <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="98r-iN-zZc"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hIz-AP-VOD">
+            <objects>
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <view key="view" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="655"/>
+        </scene>
+    </scenes>
+</document>

--- a/ProvisionQLApp/ProvisionQLApp.entitlements
+++ b/ProvisionQLApp/ProvisionQLApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/ProvisionQLApp/ViewController.h
+++ b/ProvisionQLApp/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  ProvisionQLApp
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface ViewController : NSViewController
+
+
+@end
+

--- a/ProvisionQLApp/ViewController.m
+++ b/ProvisionQLApp/ViewController.m
@@ -1,0 +1,27 @@
+//
+//  ViewController.m
+//  ProvisionQLApp
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // Do any additional setup after loading the view.
+}
+
+
+- (void)setRepresentedObject:(id)representedObject {
+    [super setRepresentedObject:representedObject];
+
+    // Update the view, if already loaded.
+}
+
+
+@end

--- a/ProvisionQLApp/main.m
+++ b/ProvisionQLApp/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  ProvisionQLApp
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        // Setup code that might create autoreleased objects goes here.
+    }
+    return NSApplicationMain(argc, argv);
+}

--- a/ProvisionQLPreview/Info.plist
+++ b/ProvisionQLPreview/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLIsDataBasedPreview</key>
+			<true/>
+			<key>QLSupportedContentTypes</key>
+			<array>
+				<string>com.apple.itunes.ipa</string>
+				<string>com.apple.mobileprovision</string>
+				<string>com.apple.iphone.mobileprovision</string>
+				<string>com.apple.provisionprofile</string>
+				<string>com.apple.xcode.archive</string>
+				<string>com.apple.application-and-system-extension</string>
+			</array>
+			<key>QLSupportsSearchableItems</key>
+			<false/>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.quicklook.preview</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>PreviewProvider</string>
+	</dict>
+</dict>
+</plist>

--- a/ProvisionQLPreview/NSBundle+ProvisionQL.m
+++ b/ProvisionQLPreview/NSBundle+ProvisionQL.m
@@ -1,0 +1,18 @@
+//
+//  NSBundle+ProvisionQL.m
+//  ProvisionQL
+//
+//  Created by Daniel Muhra on 26.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import "NSBundle+ProvisionQL.h"
+#import "PreviewProvider.h"
+
+@implementation NSBundle (ProvisionQL)
+
++ (NSBundle*) pluginBundle {
+    return [NSBundle bundleForClass:[PreviewProvider class]];
+}
+
+@end

--- a/ProvisionQLPreview/PreviewProvider.h
+++ b/ProvisionQLPreview/PreviewProvider.h
@@ -1,0 +1,14 @@
+//
+//  PreviewProvider.h
+//  ProvisionQLPreview
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import <Quartz/Quartz.h>
+
+@interface PreviewProvider : QLPreviewProvider <QLPreviewingController>
+
+@end

--- a/ProvisionQLPreview/PreviewProvider.m
+++ b/ProvisionQLPreview/PreviewProvider.m
@@ -1,0 +1,59 @@
+//
+//  PreviewProvider.m
+//  ProvisionQLPreview
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import "PreviewProvider.h"
+
+@implementation PreviewProvider
+
+/*
+
+ Use a QLPreviewProvider to provide data-based previews.
+ 
+ To set up your extension as a data-based preview extension:
+
+ - Modify the extension's Info.plist by setting
+   <key>QLIsDataBasedPreview</key>
+   <true/>
+ 
+ - Add the supported content types to QLSupportedContentTypes array in the extension's Info.plist.
+
+ - Change the NSExtensionPrincipalClass to this class.
+   e.g.
+   <key>NSExtensionPrincipalClass</key>
+   <string>PreviewProvider</string>
+ 
+ - Implement providePreviewForFileRequest:completionHandler:
+ 
+ */
+
+- (void)providePreviewForFileRequest:(QLFilePreviewRequest *)request completionHandler:(void (^)(QLPreviewReply * _Nullable reply, NSError * _Nullable error))handler
+{
+    //You can create a QLPreviewReply in several ways, depending on the format of the data you want to return.
+    //To return NSData of a supported content type:
+    
+    UTType* contentType = UTTypeUTF8PlainText; //replace with your data type
+    
+    QLPreviewReply* reply = [[QLPreviewReply alloc] initWithDataOfContentType:contentType contentSize:CGSizeMake(800, 800) dataCreationBlock:^NSData * _Nullable(QLPreviewReply * _Nonnull replyToUpdate, NSError *__autoreleasing  _Nullable * _Nullable error) {
+        
+        NSData* data = [@"Hello world" dataUsingEncoding:NSUTF8StringEncoding];
+        
+        //setting the stringEncoding for text and html data is optional and defaults to NSUTF8StringEncoding
+        replyToUpdate.stringEncoding = NSUTF8StringEncoding;
+        
+        //initialize your data here
+        
+        return data;
+    }];
+    
+    //You can also create a QLPreviewReply with a fileURL of a supported file type, by drawing directly into a bitmap context, or by providing a PDFDocument.
+    
+    handler(reply, nil);
+}
+
+@end
+

--- a/ProvisionQLPreview/PreviewProvider.m
+++ b/ProvisionQLPreview/PreviewProvider.m
@@ -8,6 +8,8 @@
 
 #import "PreviewProvider.h"
 
+NSData* generatePreviewDataForURL(NSURL *URL, NSString *dataType);
+
 @implementation PreviewProvider
 
 /*
@@ -36,18 +38,15 @@
     //You can create a QLPreviewReply in several ways, depending on the format of the data you want to return.
     //To return NSData of a supported content type:
     
-    UTType* contentType = UTTypeUTF8PlainText; //replace with your data type
+    UTType* contentType = UTTypeHTML; //replace with your data type
     
     QLPreviewReply* reply = [[QLPreviewReply alloc] initWithDataOfContentType:contentType contentSize:CGSizeMake(800, 800) dataCreationBlock:^NSData * _Nullable(QLPreviewReply * _Nonnull replyToUpdate, NSError *__autoreleasing  _Nullable * _Nullable error) {
-        
-        NSData* data = [@"Hello world" dataUsingEncoding:NSUTF8StringEncoding];
-        
-        //setting the stringEncoding for text and html data is optional and defaults to NSUTF8StringEncoding
-        replyToUpdate.stringEncoding = NSUTF8StringEncoding;
-        
-        //initialize your data here
-        
-        return data;
+        UTType *fileUTI = [UTType typeWithFilenameExtension:request.fileURL.pathExtension];
+        if (fileUTI) {
+            return generatePreviewDataForURL(request.fileURL, fileUTI.identifier);
+        }
+
+        return nil;
     }];
     
     //You can also create a QLPreviewReply with a fileURL of a supported file type, by drawing directly into a bitmap context, or by providing a PDFDocument.

--- a/ProvisionQLPreview/ProvisionQLPreview.entitlements
+++ b/ProvisionQLPreview/ProvisionQLPreview.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/ProvisionQLThumbnail/Info.plist
+++ b/ProvisionQLThumbnail/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLSupportedContentTypes</key>
+			<array>
+				<string>com.apple.itunes.ipa</string>
+				<string>com.apple.xcode.archive</string>
+			</array>
+			<key>QLThumbnailMinimumDimension</key>
+			<integer>0</integer>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.quicklook.thumbnail</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>ThumbnailProvider</string>
+	</dict>
+</dict>
+</plist>

--- a/ProvisionQLThumbnail/NSBundle+ProvisionQL.m
+++ b/ProvisionQLThumbnail/NSBundle+ProvisionQL.m
@@ -1,0 +1,18 @@
+//
+//  NSBundle+ProvisionQL.m
+//  ProvisionQL
+//
+//  Created by Daniel Muhra on 26.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import "NSBundle+ProvisionQL.h"
+#import "ThumbnailProvider.h"
+
+@implementation NSBundle (ProvisionQL)
+
++ (NSBundle*) pluginBundle {
+    return [NSBundle bundleForClass:[ThumbnailProvider class]];
+}
+
+@end

--- a/ProvisionQLThumbnail/ProvisionQLThumbnail.entitlements
+++ b/ProvisionQLThumbnail/ProvisionQLThumbnail.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/ProvisionQLThumbnail/ThumbnailProvider.h
+++ b/ProvisionQLThumbnail/ThumbnailProvider.h
@@ -1,0 +1,17 @@
+//
+//  ThumbnailProvider.h
+//  ProvisionQLThumbnail
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import <QuickLookThumbnailing/QuickLookThumbnailing.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ThumbnailProvider : QLThumbnailProvider
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ProvisionQLThumbnail/ThumbnailProvider.m
+++ b/ProvisionQLThumbnail/ThumbnailProvider.m
@@ -7,6 +7,13 @@
 //
 
 #import "ThumbnailProvider.h"
+#import "Shared.h"
+#import "ProvisioninProfileThumbnailData.h"
+
+
+NSImage* generateThumbnailForArchive(NSURL *URL, NSString *dataType);
+ProvisioninProfileThumbnailData* generateProvisioningProfileData(NSURL *URL, NSString *dataType, BOOL iconMode);
+void drawProvisioningProfileThumbnail(CGContextRef _context, NSImage* appIcon, NSUInteger devicesCount, int expStatus, BOOL iconMode);
 
 @implementation ThumbnailProvider
 
@@ -14,13 +21,48 @@
     
     // There are three ways to provide a thumbnail through a QLThumbnailReply. Only one of them should be used.
     
-    // First way: Draw the thumbnail into the current context, set up with AppKit's coordinate system.
-    handler([QLThumbnailReply replyWithContextSize:request.maximumSize currentContextDrawingBlock:^BOOL {
-        // Draw the thumbnail here.
+    NSString *fileUTI = [[UTType typeWithFilenameExtension:request.fileURL.pathExtension] identifier];
+
+    if ([fileUTI isEqualToString:kDataType_ipa] || [fileUTI isEqualToString:kDataType_xcode_archive]) {
+        QLThumbnailReply* reply = [QLThumbnailReply replyWithContextSize:request.maximumSize currentContextDrawingBlock:^BOOL{
+            CGContextRef context = [NSGraphicsContext currentContext].CGContext;
+
+            // Clear the background to be fully transparent
+            CGContextClearRect(context, CGRectMake(0, 0, request.maximumSize.width, request.maximumSize.height));
+            
+            
+            NSImage* appImage = generateThumbnailForArchive(request.fileURL, fileUTI);
+            // Calculate aspect-fit rectangle
+            CGSize imageSize = appImage.size;
+            CGSize maxSize = request.maximumSize;
+            
+            CGFloat scale = MIN(maxSize.width / imageSize.width, maxSize.height / imageSize.height);
+            CGSize scaledSize = CGSizeMake(imageSize.width * scale, imageSize.height * scale);
+            
+            CGRect imageRect = CGRectMake((maxSize.width - scaledSize.width) / 2.0,
+                                          (maxSize.height - scaledSize.height) / 2.0,
+                                          scaledSize.width,
+                                          scaledSize.height);
+
+            // Draw the image in the calculated aspect-fit rectangle
+            [appImage drawInRect:imageRect];
+            
+            return YES;
+        }];
+        reply.extensionBadge = @"ASDF";
         
-        // Return YES if the thumbnail was successfully drawn inside this block.
-        return YES;
-    }], nil);
+        handler(reply, nil);
+    }
+    else {
+        handler([QLThumbnailReply replyWithContextSize:request.maximumSize drawingBlock:^BOOL(CGContextRef  _Nonnull context) {
+            ProvisioninProfileThumbnailData* data = generateProvisioningProfileData(request.fileURL, fileUTI, YES);
+            drawProvisioningProfileThumbnail(context, data.appIcon, data.devicesCount, data.expStatus, YES);
+            // Draw the thumbnail here.
+        
+            // Return YES if the thumbnail was successfully drawn inside this block.
+            return YES;
+        }], nil);
+    }
     
     /*
      

--- a/ProvisionQLThumbnail/ThumbnailProvider.m
+++ b/ProvisionQLThumbnail/ThumbnailProvider.m
@@ -1,0 +1,41 @@
+//
+//  ThumbnailProvider.m
+//  ProvisionQLThumbnail
+//
+//  Created by Daniel Muhra on 31.10.24.
+//  Copyright © 2024 Evgeny Aleksandrov. All rights reserved.
+//
+
+#import "ThumbnailProvider.h"
+
+@implementation ThumbnailProvider
+
+- (void)provideThumbnailForFileRequest:(QLFileThumbnailRequest *)request completionHandler:(void (^)(QLThumbnailReply * _Nullable, NSError * _Nullable))handler {
+    
+    // There are three ways to provide a thumbnail through a QLThumbnailReply. Only one of them should be used.
+    
+    // First way: Draw the thumbnail into the current context, set up with AppKit's coordinate system.
+    handler([QLThumbnailReply replyWithContextSize:request.maximumSize currentContextDrawingBlock:^BOOL {
+        // Draw the thumbnail here.
+        
+        // Return YES if the thumbnail was successfully drawn inside this block.
+        return YES;
+    }], nil);
+    
+    /*
+     
+     // Second way: Draw the thumbnail into a context passed to your block, set up with Core Graphics's coordinate system.
+     handler([QLThumbnailReply replyWithContextSize:request.maximumSize drawingBlock:^BOOL(CGContextRef  _Nonnull context) {
+     // Draw the thumbnail here.
+     
+     // Return YES if the thumbnail was successfully drawn inside this block.
+     return YES;
+     }], nil);
+     
+     // Third way: Set an image file URL.
+     handler([QLThumbnailReply replyWithImageFileURL:[NSBundle.mainBundle URLForResource:@"fileThumbnail" withExtension:@"jpg"]], nil);
+     
+     */
+}
+
+@end


### PR DESCRIPTION
- Replace NSTask invocation of codesign with equivalent code
- Introduce pluginBundle method for NSBundle: Makes it easier to provide different implementations per target
- Main intention is to prepare the migration to QLPreviewProvider. This will require to create a sandboxed app extension which may not involve creating such NSTasks