### PR TITLE
Refactor parser architecture

### DIFF
--- a/Preview/PreviewViewController.swift
+++ b/Preview/PreviewViewController.swift
@@ -42,7 +42,7 @@ final class PreviewModel {
             content = try await Self.loadContent(for: url)
         } catch {
             let fileInfo = await Self.fileInfo(for: url)
-            content = .failed(error, url, fileInfo)
+            content = .failed(error, fileInfo)
         }
     }
 }
@@ -89,7 +89,7 @@ enum PreviewContent {
     case loading
     case profile(ProvisioningInfo, FileInfo)
     case archive(AppInfo, NSImage?, FileInfo)
-    case failed(Error, URL, FileInfo)
+    case failed(Error, FileInfo)
 }
 
 struct PreviewRootView: View {
@@ -104,8 +104,8 @@ struct PreviewRootView: View {
             ProvisioningPreviewView(info: info, fileInfo: fileInfo)
         case .archive(let appInfo, let icon, let fileInfo):
             AppArchivePreviewView(appInfo: appInfo, icon: icon, fileInfo: fileInfo)
-        case .failed(let error, let fileURL, let fileInfo):
-            FailedDocumentView(error: error, fileURL: fileURL, fileInfo: fileInfo)
+        case .failed(let error, let fileInfo):
+            FailedDocumentView(error: error, fileInfo: fileInfo)
         }
     }
 }

--- a/Preview/PreviewViewController.swift
+++ b/Preview/PreviewViewController.swift
@@ -54,8 +54,12 @@ class PreviewViewController: NSViewController, QLPreviewingController {
 
     private func showAppArchivePreview(for url: URL) {
         do {
-            let appInfo = try AppArchiveParser.parse(url)
-            let previewView = AppArchivePreviewView(appInfo: appInfo, fileURL: url)
+            let result = try AppArchiveParser.parseWithResources(url)
+            let previewView = AppArchivePreviewView(
+                appInfo: result.appInfo,
+                icon: result.iconSource?.makeImage(),
+                fileURL: url
+            )
             hostingController?.rootView = AnyView(previewView)
         } catch {
             showFailure(error, fileURL: url)

--- a/Preview/PreviewViewController.swift
+++ b/Preview/PreviewViewController.swift
@@ -5,18 +5,18 @@
 //  Created by Evgeny Aleksandrov
 
 import Cocoa
+import Observation
 import ProvisionQLCore
 import Quartz
 import SwiftUI
 import UniformTypeIdentifiers
 
 class PreviewViewController: NSViewController, QLPreviewingController {
-    private var hostingController: NSHostingController<AnyView>?
+    private let model = PreviewModel()
+    private var hostingController: NSHostingController<PreviewRootView>?
 
     override func loadView() {
-        let placeholderView = ProvisioningPreviewView(info: nil, fileURL: nil)
-
-        let hostingController = NSHostingController(rootView: AnyView(placeholderView))
+        let hostingController = NSHostingController(rootView: PreviewRootView(model: model))
         self.hostingController = hostingController
 
         view = hostingController.view
@@ -26,58 +26,99 @@ class PreviewViewController: NSViewController, QLPreviewingController {
     }
 
     func preparePreviewOfFile(at url: URL) async throws {
-        let fileType: UTType?
-        do {
-            fileType = try url.resourceValues(forKeys: [.contentTypeKey]).contentType
-        } catch {
-            showFailure(error, fileURL: url)
-            return
-        }
+        await model.previewRequested(for: url)
+    }
+}
 
-        if let contentType = fileType {
-            // Check for IPA files (which conform to data) or xcarchive files (which conform to package)
-            if contentType.identifier == "com.apple.itunes.ipa" ||
-                contentType.identifier == "com.apple.xcode.archive"
-            {
-                showAppArchivePreview(for: url)
-            } else if contentType.identifier == "com.apple.application-and-system-extension" {
-                showAppArchivePreview(for: url)
-            } else {
-                // Handle provisioning profile files
-                showProvisioningProfilePreview(for: url)
-            }
-        } else {
-            // Fallback to provisioning profile parsing
-            showProvisioningProfilePreview(for: url)
+@MainActor
+@Observable
+final class PreviewModel {
+    var content: PreviewContent = .loading
+
+    func previewRequested(for url: URL) async {
+        content = .loading
+
+        do {
+            content = try await Self.loadContent(for: url)
+        } catch {
+            let fileInfo = await Self.fileInfo(for: url)
+            content = .failed(error, url, fileInfo)
         }
     }
+}
 
-    private func showAppArchivePreview(for url: URL) {
-        do {
+private extension PreviewModel {
+    static func loadContent(for url: URL) async throws -> PreviewContent {
+        let contentType = try url.resourceValues(forKeys: [.contentTypeKey]).contentType
+
+        if let contentType, contentType.isAppArchive {
+            return try await loadAppArchiveContent(for: url)
+        }
+
+        return try await loadProvisioningProfileContent(for: url)
+    }
+
+    static func loadAppArchiveContent(for url: URL) async throws -> PreviewContent {
+        let (result, fileInfo) = try await Task.detached(priority: .userInitiated) {
             let result = try AppArchiveParser.parseWithResources(url)
-            let previewView = AppArchivePreviewView(
-                appInfo: result.appInfo,
-                icon: result.iconSource?.makeImage(),
-                fileURL: url
-            )
-            hostingController?.rootView = AnyView(previewView)
-        } catch {
-            showFailure(error, fileURL: url)
-        }
+            let fileInfo = FileInfo(fileURL: url)
+            return (result, fileInfo)
+        }.value
+
+        return .archive(result.appInfo, result.iconSource?.makeImage(), fileInfo)
     }
 
-    private func showProvisioningProfilePreview(for url: URL) {
-        do {
+    static func loadProvisioningProfileContent(for url: URL) async throws -> PreviewContent {
+        let (info, fileInfo) = try await Task.detached(priority: .userInitiated) {
             let info = try ProvisioningParser.parse(url)
-            let previewView = ProvisioningPreviewView(info: info, fileURL: url)
-            hostingController?.rootView = AnyView(previewView)
-        } catch {
-            showFailure(error, fileURL: url)
-        }
+            let fileInfo = FileInfo(fileURL: url)
+            return (info, fileInfo)
+        }.value
+
+        return .profile(info, fileInfo)
     }
 
-    private func showFailure(_ error: Error, fileURL: URL) {
-        let previewView = FailedDocumentView(error: error, fileURL: fileURL)
-        hostingController?.rootView = AnyView(previewView)
+    static func fileInfo(for url: URL) async -> FileInfo {
+        await Task.detached(priority: .utility) {
+            FileInfo(fileURL: url)
+        }.value
+    }
+}
+
+enum PreviewContent {
+    case loading
+    case profile(ProvisioningInfo, FileInfo)
+    case archive(AppInfo, NSImage?, FileInfo)
+    case failed(Error, URL, FileInfo)
+}
+
+struct PreviewRootView: View {
+    let model: PreviewModel
+
+    var body: some View {
+        switch model.content {
+        case .loading:
+            ProgressView()
+                .frame(minWidth: UIConstants.Window.minWidth, minHeight: UIConstants.Window.minHeight)
+        case .profile(let info, let fileInfo):
+            ProvisioningPreviewView(info: info, fileInfo: fileInfo)
+        case .archive(let appInfo, let icon, let fileInfo):
+            AppArchivePreviewView(appInfo: appInfo, icon: icon, fileInfo: fileInfo)
+        case .failed(let error, let fileURL, let fileInfo):
+            FailedDocumentView(error: error, fileURL: fileURL, fileInfo: fileInfo)
+        }
+    }
+}
+
+private extension UTType {
+    var isAppArchive: Bool {
+        switch identifier {
+        case "com.apple.itunes.ipa",
+             "com.apple.xcode.archive",
+             "com.apple.application-and-system-extension":
+            true
+        default:
+            false
+        }
     }
 }

--- a/Preview/Views/AppArchivePreviewView.swift
+++ b/Preview/Views/AppArchivePreviewView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AppArchivePreviewView: View {
     let appInfo: AppInfo
+    let icon: NSImage?
     let fileURL: URL?
 
     var body: some View {
@@ -75,7 +76,7 @@ struct AppArchivePreviewView: View {
 private extension AppArchivePreviewView {
     func appHeader() -> some View {
         HStack(alignment: .top, spacing: UIConstants.Padding.large) {
-            if let icon = appInfo.icon {
+            if let icon {
                 Image(nsImage: icon)
                     .resizable()
                     .aspectRatio(contentMode: .fit)

--- a/Preview/Views/AppArchivePreviewView.swift
+++ b/Preview/Views/AppArchivePreviewView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AppArchivePreviewView: View {
     let appInfo: AppInfo
     let icon: NSImage?
-    let fileURL: URL?
+    let fileInfo: FileInfo?
 
     var body: some View {
         ScrollView {
@@ -59,9 +59,9 @@ struct AppArchivePreviewView: View {
                     embeddedProfileSection(profile: profile)
                 }
 
-                if let fileURL {
+                if let fileInfo {
                     section(title: "File Info") {
-                        FileInfoSection(fileURL: fileURL)
+                        FileInfoSection(fileInfo: fileInfo)
                     }
                 }
 
@@ -173,8 +173,7 @@ private extension AppArchivePreviewView {
     }
 
     var isAppExtension: Bool {
-        guard let fileURL else { return false }
-        return fileURL.pathExtension.lowercased() == "appex"
+        appInfo.extensionPointIdentifier != nil || fileInfo?.fileName.lowercased().hasSuffix(".appex") == true
     }
 }
 

--- a/Preview/Views/AppArchivePreviewView.swift
+++ b/Preview/Views/AppArchivePreviewView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AppArchivePreviewView: View {
     let appInfo: AppInfo
     let icon: NSImage?
-    let fileInfo: FileInfo?
+    let fileInfo: FileInfo
 
     var body: some View {
         ScrollView {
@@ -59,10 +59,8 @@ struct AppArchivePreviewView: View {
                     embeddedProfileSection(profile: profile)
                 }
 
-                if let fileInfo {
-                    section(title: "File Info") {
-                        FileInfoSection(fileInfo: fileInfo)
-                    }
+                section(title: "File Info") {
+                    FileInfoSection(fileInfo: fileInfo)
                 }
 
                 footer()
@@ -173,7 +171,7 @@ private extension AppArchivePreviewView {
     }
 
     var isAppExtension: Bool {
-        appInfo.extensionPointIdentifier != nil || fileInfo?.fileName.lowercased().hasSuffix(".appex") == true
+        appInfo.extensionPointIdentifier != nil || fileInfo.fileName.lowercased().hasSuffix(".appex")
     }
 }
 

--- a/Preview/Views/FileInfoSection.swift
+++ b/Preview/Views/FileInfoSection.swift
@@ -6,36 +6,49 @@
 
 import SwiftUI
 
+struct FileInfo: Hashable {
+    let fileName: String
+    let fileSize: String
+    let modificationDate: String
+
+    init(fileURL: URL) {
+        fileName = fileURL.lastPathComponent
+
+        let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+        fileSize = Self.formattedFileSize(for: fileURL, attributes: attributes)
+        modificationDate = Self.formattedModificationDate(from: attributes)
+    }
+}
+
 struct FileInfoSection: View {
-    let fileURL: URL
+    let fileInfo: FileInfo
 
-    var fileAttributes: [FileAttributeKey: Any]? {
-        try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+    var body: some View {
+        VStack(alignment: .leading, spacing: UIConstants.Padding.small) {
+            Text(fileInfo.fileName)
+                .codeText()
+
+            Text("\(fileInfo.fileSize), Modified \(fileInfo.modificationDate)")
+                .codeText(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .sectionBackground()
     }
+}
 
-    var fileName: String {
-        fileURL.lastPathComponent
-    }
+private extension FileInfo {
+    static func formattedFileSize(for fileURL: URL, attributes: [FileAttributeKey: Any]?) -> String {
+        let size: Int64
 
-    var fileSize: String {
-        var size: Int64 = 0
-
-        // Check if the URL is a directory
         var isDirectory: ObjCBool = false
         if FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory),
            isDirectory.boolValue
         {
-            // Calculate total size of directory contents
             size = calculateDirectorySize(at: fileURL)
+        } else if let fileSize = attributes?[.size] as? NSNumber {
+            size = fileSize.int64Value
         } else {
-            // For regular files, use the file attributes
-            if let fileAttributes,
-               let fileSize = fileAttributes[.size] as? NSNumber
-            {
-                size = fileSize.int64Value
-            } else {
-                return "Unknown size"
-            }
+            return "Unknown size"
         }
 
         let formatter = ByteCountFormatter()
@@ -43,29 +56,15 @@ struct FileInfoSection: View {
         return formatter.string(fromByteCount: size)
     }
 
-    var modificationDate: String {
-        guard let attributes = fileAttributes,
-              let date = attributes[.modificationDate] as? Date
-        else {
+    static func formattedModificationDate(from attributes: [FileAttributeKey: Any]?) -> String {
+        guard let date = attributes?[.modificationDate] as? Date else {
             return "Unknown date"
         }
 
         return date.formatted(date: .long, time: .standard)
     }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: UIConstants.Padding.small) {
-            Text(fileName)
-                .codeText()
-
-            Text("\(fileSize), Modified \(modificationDate)")
-                .codeText(.subheadline)
-                .foregroundColor(.secondary)
-        }
-        .sectionBackground()
-    }
-
-    private func calculateDirectorySize(at url: URL) -> Int64 {
+    static func calculateDirectorySize(at url: URL) -> Int64 {
         var totalSize: Int64 = 0
 
         let fileManager = FileManager.default

--- a/Preview/Views/ProvisioningPreviewView.swift
+++ b/Preview/Views/ProvisioningPreviewView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct ProvisioningPreviewView: View {
     let info: ProvisioningInfo?
-    let fileURL: URL?
+    let fileInfo: FileInfo?
 
     var body: some View {
         if let info {
@@ -53,9 +53,9 @@ private extension ProvisioningPreviewView {
                     }
                 }
 
-                if let fileURL {
+                if let fileInfo {
                     section(title: "File Info") {
-                        FileInfoSection(fileURL: fileURL)
+                        FileInfoSection(fileInfo: fileInfo)
                     }
                 }
 
@@ -147,6 +147,7 @@ struct DiagnosticsSection: View {
 struct FailedDocumentView: View {
     let error: Error
     let fileURL: URL?
+    let fileInfo: FileInfo?
 
     var body: some View {
         ScrollView {
@@ -168,9 +169,9 @@ struct FailedDocumentView: View {
                     }
                 }
 
-                if let fileURL {
+                if let fileInfo {
                     section(title: "File Info") {
-                        FileInfoSection(fileURL: fileURL)
+                        FileInfoSection(fileInfo: fileInfo)
                     }
                 }
 

--- a/Preview/Views/ProvisioningPreviewView.swift
+++ b/Preview/Views/ProvisioningPreviewView.swift
@@ -9,15 +9,11 @@ import Quartz
 import SwiftUI
 
 struct ProvisioningPreviewView: View {
-    let info: ProvisioningInfo?
-    let fileInfo: FileInfo?
+    let info: ProvisioningInfo
+    let fileInfo: FileInfo
 
     var body: some View {
-        if let info {
-            documentContent(for: info)
-        } else {
-            ProgressView()
-        }
+        documentContent(for: info)
     }
 }
 
@@ -53,10 +49,8 @@ private extension ProvisioningPreviewView {
                     }
                 }
 
-                if let fileInfo {
-                    section(title: "File Info") {
-                        FileInfoSection(fileInfo: fileInfo)
-                    }
+                section(title: "File Info") {
+                    FileInfoSection(fileInfo: fileInfo)
                 }
 
                 footer()
@@ -146,13 +140,12 @@ struct DiagnosticsSection: View {
 
 struct FailedDocumentView: View {
     let error: Error
-    let fileURL: URL?
-    let fileInfo: FileInfo?
+    let fileInfo: FileInfo
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
-                Text("\(fileURL?.lastPathComponent ?? "Profile") could not be parsed")
+                Text("\(fileInfo.fileName) could not be parsed")
                     .font(.title)
                     .fontWeight(.bold)
 
@@ -169,10 +162,8 @@ struct FailedDocumentView: View {
                     }
                 }
 
-                if let fileInfo {
-                    section(title: "File Info") {
-                        FileInfoSection(fileInfo: fileInfo)
-                    }
+                section(title: "File Info") {
+                    FileInfoSection(fileInfo: fileInfo)
                 }
 
                 footer()

--- a/ProvisionQLCore/Sources/AppArchiveParseResult.swift
+++ b/ProvisionQLCore/Sources/AppArchiveParseResult.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct AppArchiveParseResult: Sendable, Codable, Hashable {
+    public let appInfo: AppInfo
+    public let iconSource: IconSource?
+
+    public init(appInfo: AppInfo, iconSource: IconSource? = nil) {
+        self.appInfo = appInfo
+        self.iconSource = iconSource
+    }
+}

--- a/ProvisionQLCore/Sources/AppArchiveParser.swift
+++ b/ProvisionQLCore/Sources/AppArchiveParser.swift
@@ -5,10 +5,13 @@
 //  Created by Evgeny Aleksandrov
 
 import Foundation
-import ZIPFoundation
 
 public enum AppArchiveParser {
     public static func parse(_ url: URL) throws -> AppInfo {
+        try parseWithResources(url).appInfo
+    }
+
+    public static func parseWithResources(_ url: URL) throws -> AppArchiveParseResult {
         let fileExtension = url.pathExtension.lowercased()
 
         switch fileExtension {
@@ -25,45 +28,12 @@ public enum AppArchiveParser {
 }
 
 private extension AppArchiveParser {
-    static func parseIPA(_ url: URL) throws -> AppInfo {
-        let archive = try Archive(url: url, accessMode: .read)
-
-        // Find the app bundle path within the archive
-        let appBundlePath = try ArchiveUtilities.findAppBundlePath(in: archive, archiveType: .ipa)
-
-        // Extract Info.plist
-        let infoPlistPath = appBundlePath + "Info.plist"
-        let infoPlistData = try ArchiveUtilities.extractFile(from: archive, path: infoPlistPath)
-        let plist = try PlistParser.parse(data: infoPlistData)
-
-        // Parse app information
-        let appInfo = PlistParser.extractAppInfo(from: plist)
-
-        // Extract app icon using the dedicated IconExtractor
-        let icon = try? IconExtractor.extractIcon(from: url)
-
-        // Extract embedded provisioning profile
-        let embeddedProfile = ProvisioningProfileExtractor.extractFromArchive(archive, appBundlePath: appBundlePath)
-
-        // Extract app entitlements
-        let entitlements = extractAppEntitlements(from: archive, appBundlePath: appBundlePath)
-
-        return AppInfo(
-            name: appInfo.name,
-            bundleIdentifier: appInfo.bundleIdentifier,
-            version: appInfo.version,
-            buildNumber: appInfo.buildNumber,
-            icon: icon,
-            embeddedProvisioningProfile: embeddedProfile.profile,
-            entitlements: entitlements,
-            deviceFamily: appInfo.deviceFamily,
-            minimumOSVersion: appInfo.minimumOSVersion,
-            sdkVersion: appInfo.sdkVersion,
-            diagnostics: embeddedProfile.diagnostics
-        )
+    static func parseIPA(_ url: URL) throws -> AppArchiveParseResult {
+        let source = try IPAAppBundleSource(url: url)
+        return try parseApp(from: source)
     }
 
-    static func parseXCArchive(_ url: URL) throws -> AppInfo {
+    static func parseXCArchive(_ url: URL) throws -> AppArchiveParseResult {
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
               isDirectory.boolValue
@@ -71,35 +41,12 @@ private extension AppArchiveParser {
             throw ParsingError.invalidArchiveFormat
         }
 
-        let appBundleURL = try findAppBundleInXCArchive(at: url)
-        let infoPlistURL = try infoPlistURL(for: appBundleURL)
-        let plist = try PlistParser.parse(url: infoPlistURL)
-
-        let appInfo = PlistParser.extractAppInfo(from: plist)
-
-        let icon = try? IconExtractor.extractIcon(from: url)
-
-        let embeddedProfile = ProvisioningProfileExtractor.extractFromDirectory(appBundleURL)
-
-        // Extract app entitlements
-        let entitlements = EntitlementsExtractor.extractEntitlements(from: appBundleURL)
-
-        return AppInfo(
-            name: appInfo.name,
-            bundleIdentifier: appInfo.bundleIdentifier,
-            version: appInfo.version,
-            buildNumber: appInfo.buildNumber,
-            icon: icon,
-            embeddedProvisioningProfile: embeddedProfile.profile,
-            entitlements: entitlements,
-            deviceFamily: appInfo.deviceFamily,
-            minimumOSVersion: appInfo.minimumOSVersion,
-            sdkVersion: appInfo.sdkVersion,
-            diagnostics: embeddedProfile.diagnostics
-        )
+        let appBundleURL = try DirectoryAppBundleSource.findAppBundleInXCArchive(at: url)
+        let source = try DirectoryAppBundleSource(bundleURL: appBundleURL)
+        return try parseApp(from: source)
     }
 
-    static func parseAppExtension(_ url: URL) throws -> AppInfo {
+    static func parseAppExtension(_ url: URL) throws -> AppArchiveParseResult {
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
               isDirectory.boolValue
@@ -107,49 +54,51 @@ private extension AppArchiveParser {
             throw ParsingError.invalidArchiveFormat
         }
 
-        let infoPlistURL = try infoPlistURL(for: url)
-        let plist = try PlistParser.parse(url: infoPlistURL)
+        let source = try DirectoryAppBundleSource(bundleURL: url)
+        return try parseApp(from: source, isAppExtension: true)
+    }
 
-        let appInfo = PlistParser.extractAppInfo(from: plist)
+    static func parseApp(from source: AppBundleSource, isAppExtension: Bool = false) throws -> AppArchiveParseResult {
+        let plist = try source.infoPlist()
 
-        let icon = try? IconExtractor.extractIcon(from: url)
+        let parsedAppInfo = PlistParser.extractAppInfo(from: plist)
 
-        let embeddedProfile = ProvisioningProfileExtractor.extractFromDirectory(url)
+        let iconSource = try? IconExtractor.extractIconSource(from: source)
+        let embeddedProfile = source.embeddedProvisioningProfile()
 
-        // Extract extension type from NSExtension dictionary
         var extensionType: String?
         var extensionPointIdentifier: String?
-        if let nsExtension = plist["NSExtension"] as? [String: Any],
+        if isAppExtension,
+           let nsExtension = plist["NSExtension"] as? [String: Any],
            let identifier = nsExtension["NSExtensionPointIdentifier"] as? String
         {
             extensionPointIdentifier = identifier
             extensionType = parseExtensionType(from: identifier)
         }
 
-        // For app extensions, append the extension type to the name
-        let displayName = if let extensionType {
-            "\(appInfo.name) (\(extensionType))"
+        let displayName = if isAppExtension, let extensionType {
+            "\(parsedAppInfo.name) (\(extensionType))"
         } else {
-            appInfo.name
+            parsedAppInfo.name
         }
 
-        // Extract app entitlements
-        let entitlements = EntitlementsExtractor.extractEntitlements(from: url)
+        let entitlements = source.extractEntitlements(infoPlist: plist)
 
-        return AppInfo(
+        let appInfo = AppInfo(
             name: displayName,
-            bundleIdentifier: appInfo.bundleIdentifier,
-            version: appInfo.version,
-            buildNumber: appInfo.buildNumber,
-            icon: icon,
+            bundleIdentifier: parsedAppInfo.bundleIdentifier,
+            version: parsedAppInfo.version,
+            buildNumber: parsedAppInfo.buildNumber,
             embeddedProvisioningProfile: embeddedProfile.profile,
             entitlements: entitlements,
-            deviceFamily: appInfo.deviceFamily,
-            minimumOSVersion: appInfo.minimumOSVersion,
-            sdkVersion: appInfo.sdkVersion,
+            deviceFamily: parsedAppInfo.deviceFamily,
+            minimumOSVersion: parsedAppInfo.minimumOSVersion,
+            sdkVersion: parsedAppInfo.sdkVersion,
             extensionPointIdentifier: extensionPointIdentifier,
             diagnostics: embeddedProfile.diagnostics
         )
+
+        return AppArchiveParseResult(appInfo: appInfo, iconSource: iconSource)
     }
 
     static func parseExtensionType(from identifier: String) -> String {
@@ -196,105 +145,6 @@ private extension AppArchiveParser {
             "Safari Extension"
         default:
             "App Extension"
-        }
-    }
-
-    static func findAppBundleInXCArchive(at archiveURL: URL) throws -> URL {
-        let productsPath = archiveURL.appendingPathComponent("Products", isDirectory: true)
-
-        if let applicationPath = applicationPathInXCArchive(at: archiveURL) {
-            let normalizedPath = applicationPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-            let candidates = [
-                productsPath.appendingPathComponent(normalizedPath, isDirectory: true),
-                archiveURL.appendingPathComponent(normalizedPath, isDirectory: true)
-            ]
-
-            for candidate in candidates where isAppBundle(candidate) {
-                return candidate
-            }
-        }
-
-        let applicationsPath = productsPath.appendingPathComponent("Applications", isDirectory: true)
-        let appBundles = try FileManager.default.contentsOfDirectory(
-            at: applicationsPath,
-            includingPropertiesForKeys: nil
-        )
-        .filter(isAppBundle)
-        .sorted { lhs, rhs in
-            lhs.lastPathComponent.localizedStandardCompare(rhs.lastPathComponent) == .orderedAscending
-        }
-
-        guard let appBundleURL = appBundles.first else {
-            throw ParsingError.invalidAppBundle
-        }
-
-        return appBundleURL
-    }
-
-    static func applicationPathInXCArchive(at archiveURL: URL) -> String? {
-        let infoPlistURL = archiveURL.appendingPathComponent("Info.plist")
-        guard
-            let plist = try? PlistParser.parse(url: infoPlistURL),
-            let applicationProperties = plist["ApplicationProperties"] as? [String: Any],
-            let applicationPath = applicationProperties["ApplicationPath"] as? String,
-            !applicationPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
-            return nil
-        }
-
-        return applicationPath
-    }
-
-    static func infoPlistURL(for bundleURL: URL) throws -> URL {
-        let candidates = [
-            bundleURL.appendingPathComponent("Contents/Info.plist"),
-            bundleURL.appendingPathComponent("Info.plist")
-        ]
-
-        for candidate in candidates where FileManager.default.fileExists(atPath: candidate.path) {
-            return candidate
-        }
-
-        throw ParsingError.missingInfoPlist
-    }
-
-    static func isAppBundle(_ url: URL) -> Bool {
-        var isDirectory: ObjCBool = false
-        return url.pathExtension == "app"
-            && FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
-    }
-
-    static func extractAppEntitlements(from archive: Archive, appBundlePath: String) -> [String: PlistValue] {
-        // First, try to find the executable name from Info.plist
-        let infoPlistPath = appBundlePath + "Info.plist"
-        guard let infoPlistData = try? ArchiveUtilities.extractFile(from: archive, path: infoPlistPath),
-              let plist = try? PlistParser.parse(data: infoPlistData),
-              let executableName = PlistParser.extractExecutableName(from: plist)
-        else {
-            return [:]
-        }
-
-        // Extract the executable
-        let executablePath = appBundlePath + executableName
-        guard let executableData = try? ArchiveUtilities.extractFile(from: archive, path: executablePath) else {
-            return [:]
-        }
-
-        // Use the EntitlementsExtractor with temporary directory
-        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-
-        do {
-            try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
-            defer { try? FileManager.default.removeItem(at: tempDirectory) }
-
-            return EntitlementsExtractor.extractEntitlementsFromArchive(
-                executableData: executableData,
-                temporaryDirectory: tempDirectory
-            )
-        } catch {
-            return [:]
         }
     }
 }

--- a/ProvisionQLCore/Sources/AppBundleSource.swift
+++ b/ProvisionQLCore/Sources/AppBundleSource.swift
@@ -1,0 +1,273 @@
+import Foundation
+import ZIPFoundation
+
+enum AppBundleContainerKind {
+    case ipa
+    case directory
+}
+
+enum AppBundleStyle {
+    case iOS
+    case macOS
+}
+
+protocol AppBundleSource {
+    var containerKind: AppBundleContainerKind { get }
+    var bundleStyle: AppBundleStyle { get }
+
+    func data(
+        at path: String,
+        relativeToBundle: Bool,
+        caseInsensitive: Bool
+    ) throws -> Data?
+
+    func writeFile(
+        at path: String,
+        relativeToBundle: Bool,
+        to destinationURL: URL
+    ) throws -> Bool
+
+    func infoPlistData() throws -> Data
+    func extractEntitlements(infoPlist: [String: Any]) -> [String: PlistValue]
+}
+
+extension AppBundleSource {
+    func infoPlist() throws -> [String: Any] {
+        try PlistParser.parse(data: infoPlistData())
+    }
+
+    func embeddedProvisioningProfile() -> EmbeddedProvisioningProfileExtraction {
+        do {
+            for relativePath in ProvisioningProfileExtractor.embeddedProvisioningProfilePaths {
+                if let profileData = try data(
+                    at: relativePath,
+                    relativeToBundle: true,
+                    caseInsensitive: false
+                ) {
+                    return ProvisioningProfileExtractor.extract(from: profileData)
+                }
+            }
+
+            return .missing
+        } catch {
+            return .failure(error)
+        }
+    }
+}
+
+struct IPAAppBundleSource: AppBundleSource {
+    let containerKind = AppBundleContainerKind.ipa
+    let bundleStyle = AppBundleStyle.iOS
+
+    private let archive: Archive
+    private let appBundlePath: String
+
+    init(url: URL) throws {
+        archive = try Archive(url: url, accessMode: .read)
+        appBundlePath = try ArchiveUtilities.findAppBundlePath(in: archive, archiveType: .ipa)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
+
+    func data(
+        at path: String,
+        relativeToBundle: Bool,
+        caseInsensitive: Bool
+    ) throws -> Data? {
+        let archivePath = archivePath(for: path, relativeToBundle: relativeToBundle)
+
+        if caseInsensitive {
+            return try ArchiveUtilities.extractFileOptional(from: archive, path: archivePath)
+        }
+
+        return try? ArchiveUtilities.extractFile(from: archive, path: archivePath)
+    }
+
+    func writeFile(
+        at path: String,
+        relativeToBundle: Bool,
+        to destinationURL: URL
+    ) throws -> Bool {
+        try ArchiveUtilities.extractFileOptional(
+            from: archive,
+            path: archivePath(for: path, relativeToBundle: relativeToBundle),
+            to: destinationURL
+        )
+    }
+
+    func infoPlistData() throws -> Data {
+        guard let infoPlistData = try data(
+            at: "Info.plist",
+            relativeToBundle: true,
+            caseInsensitive: false
+        ) else {
+            throw ParsingError.missingInfoPlist
+        }
+
+        return infoPlistData
+    }
+
+    func extractEntitlements(infoPlist: [String: Any]) -> [String: PlistValue] {
+        guard let executableName = PlistParser.extractExecutableName(from: infoPlist) else {
+            return [:]
+        }
+
+        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let executableURL = temporaryDirectory.appendingPathComponent(executableName)
+
+        do {
+            try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+            guard try writeFile(at: executableName, relativeToBundle: true, to: executableURL) else {
+                return [:]
+            }
+
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: executableURL.path
+            )
+
+            return EntitlementsExtractor.extractEntitlements(fromCodeAt: executableURL)
+        } catch {
+            return [:]
+        }
+    }
+
+    private func archivePath(for path: String, relativeToBundle: Bool) -> String {
+        let normalizedPath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        guard relativeToBundle else {
+            return normalizedPath
+        }
+
+        return appBundlePath + "/" + normalizedPath
+    }
+}
+
+struct DirectoryAppBundleSource: AppBundleSource {
+    let containerKind = AppBundleContainerKind.directory
+    let bundleStyle: AppBundleStyle
+
+    private let bundleURL: URL
+    private let infoPlistURL: URL
+
+    init(bundleURL: URL) throws {
+        self.bundleURL = bundleURL
+
+        let macInfoPlistURL = bundleURL.appendingPathComponent("Contents/Info.plist")
+        if FileManager.default.fileExists(atPath: macInfoPlistURL.path) {
+            bundleStyle = .macOS
+            infoPlistURL = macInfoPlistURL
+        } else {
+            bundleStyle = .iOS
+            infoPlistURL = bundleURL.appendingPathComponent("Info.plist")
+        }
+
+        guard FileManager.default.fileExists(atPath: infoPlistURL.path) else {
+            throw ParsingError.missingInfoPlist
+        }
+    }
+
+    func data(
+        at path: String,
+        relativeToBundle: Bool,
+        caseInsensitive _: Bool
+    ) throws -> Data? {
+        let fileURL = url(for: path, relativeToBundle: relativeToBundle)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
+        return try Data(contentsOf: fileURL)
+    }
+
+    func writeFile(
+        at path: String,
+        relativeToBundle: Bool,
+        to destinationURL: URL
+    ) throws -> Bool {
+        let fileURL = url(for: path, relativeToBundle: relativeToBundle)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return false
+        }
+
+        try FileManager.default.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(at: fileURL, to: destinationURL)
+        return true
+    }
+
+    func infoPlistData() throws -> Data {
+        try Data(contentsOf: infoPlistURL)
+    }
+
+    func extractEntitlements(infoPlist _: [String: Any]) -> [String: PlistValue] {
+        EntitlementsExtractor.extractEntitlements(from: bundleURL)
+    }
+
+    static func findAppBundleInXCArchive(at archiveURL: URL) throws -> URL {
+        let productsPath = archiveURL.appendingPathComponent("Products", isDirectory: true)
+
+        if let applicationPath = applicationPathInXCArchive(at: archiveURL) {
+            let normalizedPath = applicationPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            let candidates = [
+                productsPath.appendingPathComponent(normalizedPath, isDirectory: true),
+                archiveURL.appendingPathComponent(normalizedPath, isDirectory: true)
+            ]
+
+            for candidate in candidates where isAppBundle(candidate) {
+                return candidate
+            }
+        }
+
+        let applicationsPath = productsPath.appendingPathComponent("Applications", isDirectory: true)
+        let appBundles = try FileManager.default.contentsOfDirectory(
+            at: applicationsPath,
+            includingPropertiesForKeys: nil
+        )
+        .filter(isAppBundle)
+        .sorted { lhs, rhs in
+            lhs.lastPathComponent.localizedStandardCompare(rhs.lastPathComponent) == .orderedAscending
+        }
+
+        guard let appBundleURL = appBundles.first else {
+            throw ParsingError.invalidAppBundle
+        }
+
+        return appBundleURL
+    }
+
+    private func url(for path: String, relativeToBundle: Bool) -> URL {
+        let normalizedPath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        guard relativeToBundle else {
+            return URL(fileURLWithPath: normalizedPath)
+        }
+
+        return bundleURL.appendingPathComponent(normalizedPath)
+    }
+
+    private static func applicationPathInXCArchive(at archiveURL: URL) -> String? {
+        let infoPlistURL = archiveURL.appendingPathComponent("Info.plist")
+        guard
+            let plist = try? PlistParser.parse(url: infoPlistURL),
+            let applicationProperties = plist["ApplicationProperties"] as? [String: Any],
+            let applicationPath = applicationProperties["ApplicationPath"] as? String,
+            !applicationPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+
+        return applicationPath
+    }
+
+    private static func isAppBundle(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return url.pathExtension == "app"
+            && FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+    }
+}

--- a/ProvisionQLCore/Sources/AppBundleSource.swift
+++ b/ProvisionQLCore/Sources/AppBundleSource.swift
@@ -75,11 +75,11 @@ struct IPAAppBundleSource: AppBundleSource {
     ) throws -> Data? {
         let archivePath = archivePath(for: path, relativeToBundle: relativeToBundle)
 
-        if caseInsensitive {
-            return try ArchiveUtilities.extractFileOptional(from: archive, path: archivePath)
-        }
-
-        return try? ArchiveUtilities.extractFile(from: archive, path: archivePath)
+        return try ArchiveUtilities.extractFileIfPresent(
+            from: archive,
+            path: archivePath,
+            caseInsensitive: caseInsensitive
+        )
     }
 
     func writeFile(
@@ -87,10 +87,11 @@ struct IPAAppBundleSource: AppBundleSource {
         relativeToBundle: Bool,
         to destinationURL: URL
     ) throws -> Bool {
-        try ArchiveUtilities.extractFileOptional(
+        try ArchiveUtilities.extractFileIfPresent(
             from: archive,
             path: archivePath(for: path, relativeToBundle: relativeToBundle),
-            to: destinationURL
+            to: destinationURL,
+            caseInsensitive: false
         )
     }
 
@@ -172,10 +173,13 @@ struct DirectoryAppBundleSource: AppBundleSource {
     func data(
         at path: String,
         relativeToBundle: Bool,
-        caseInsensitive _: Bool
+        caseInsensitive: Bool
     ) throws -> Data? {
-        let fileURL = url(for: path, relativeToBundle: relativeToBundle)
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        guard let fileURL = existingURL(
+            for: path,
+            relativeToBundle: relativeToBundle,
+            caseInsensitive: caseInsensitive
+        ) else {
             return nil
         }
 
@@ -264,6 +268,48 @@ struct DirectoryAppBundleSource: AppBundleSource {
         }
 
         return bundleURL.appendingPathComponent(normalizedPath)
+    }
+
+    private func existingURL(
+        for path: String,
+        relativeToBundle: Bool,
+        caseInsensitive: Bool
+    ) -> URL? {
+        let fileURL = url(for: path, relativeToBundle: relativeToBundle)
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            return fileURL
+        }
+
+        guard caseInsensitive, relativeToBundle else {
+            return nil
+        }
+
+        return caseInsensitiveURL(for: path)
+    }
+
+    private func caseInsensitiveURL(for path: String) -> URL? {
+        let components = path
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            .split(separator: "/")
+            .map(String.init)
+
+        var currentURL = bundleURL
+        for component in components {
+            guard let childURLs = try? FileManager.default.contentsOfDirectory(
+                at: currentURL,
+                includingPropertiesForKeys: nil
+            ),
+                let matchingURL = childURLs.first(where: {
+                    $0.lastPathComponent.caseInsensitiveCompare(component) == .orderedSame
+                })
+            else {
+                return nil
+            }
+
+            currentURL = matchingURL
+        }
+
+        return currentURL
     }
 
     private static func applicationPathInXCArchive(at archiveURL: URL) -> String? {

--- a/ProvisionQLCore/Sources/AppBundleSource.swift
+++ b/ProvisionQLCore/Sources/AppBundleSource.swift
@@ -204,8 +204,24 @@ struct DirectoryAppBundleSource: AppBundleSource {
         try Data(contentsOf: infoPlistURL)
     }
 
-    func extractEntitlements(infoPlist _: [String: Any]) -> [String: PlistValue] {
-        EntitlementsExtractor.extractEntitlements(from: bundleURL)
+    func extractEntitlements(infoPlist: [String: Any]) -> [String: PlistValue] {
+        guard let executableName = PlistParser.extractExecutableName(from: infoPlist) else {
+            return EntitlementsExtractor.extractEntitlements(from: bundleURL)
+        }
+
+        let executablePath = switch bundleStyle {
+        case .iOS:
+            executableName
+        case .macOS:
+            "Contents/MacOS/\(executableName)"
+        }
+        let executableURL = url(for: executablePath, relativeToBundle: true)
+
+        guard FileManager.default.fileExists(atPath: executableURL.path) else {
+            return EntitlementsExtractor.extractEntitlements(from: bundleURL)
+        }
+
+        return EntitlementsExtractor.extractEntitlements(fromCodeAt: executableURL)
     }
 
     static func findAppBundleInXCArchive(at archiveURL: URL) throws -> URL {

--- a/ProvisionQLCore/Sources/AppInfo.swift
+++ b/ProvisionQLCore/Sources/AppInfo.swift
@@ -4,15 +4,13 @@
 //
 //  Created by Evgeny Aleksandrov
 
-import AppKit
 import Foundation
 
-public struct AppInfo {
+public struct AppInfo: Sendable, Codable, Hashable {
     public let name: String
     public let bundleIdentifier: String
     public let version: String
     public let buildNumber: String
-    public let icon: NSImage?
     public let embeddedProvisioningProfile: ProvisioningInfo?
     public let entitlements: [String: PlistValue]
     public let deviceFamily: [String]
@@ -26,7 +24,6 @@ public struct AppInfo {
         bundleIdentifier: String,
         version: String,
         buildNumber: String,
-        icon: NSImage? = nil,
         embeddedProvisioningProfile: ProvisioningInfo? = nil,
         entitlements: [String: PlistValue] = [:],
         deviceFamily: [String] = [],
@@ -39,7 +36,6 @@ public struct AppInfo {
         self.bundleIdentifier = bundleIdentifier
         self.version = version
         self.buildNumber = buildNumber
-        self.icon = icon
         self.embeddedProvisioningProfile = embeddedProvisioningProfile
         self.entitlements = entitlements
         self.deviceFamily = deviceFamily

--- a/ProvisionQLCore/Sources/ArchiveUtilities.swift
+++ b/ProvisionQLCore/Sources/ArchiveUtilities.swift
@@ -47,6 +47,29 @@ enum ArchiveUtilities {
         return nil
     }
 
+    /// Extracts a specific file to disk with case-insensitive search.
+    /// - Parameters:
+    ///   - archive: The ZIP archive
+    ///   - path: The path to the file within the archive
+    ///   - destinationURL: The destination file URL
+    /// - Returns: `true` if the file was found and extracted, otherwise `false`
+    /// - Throws: Error if extraction fails
+    static func extractFileOptional(from archive: Archive, path: String, to destinationURL: URL) throws -> Bool {
+        if let entry = archive[path] {
+            try extract(entry, from: archive, to: destinationURL)
+            return true
+        }
+
+        for entry in archive {
+            if entry.path.lowercased() == path.lowercased() {
+                try extract(entry, from: archive, to: destinationURL)
+                return true
+            }
+        }
+
+        return false
+    }
+
     /// Extracts data from an archive entry
     /// - Parameters:
     ///   - entry: The archive entry
@@ -59,6 +82,14 @@ enum ArchiveUtilities {
             data.append(chunk)
         }
         return data
+    }
+
+    private static func extract(_ entry: Entry, from archive: Archive, to destinationURL: URL) throws {
+        try FileManager.default.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = try archive.extract(entry, to: destinationURL)
     }
 
     // MARK: - App Bundle Path Finding

--- a/ProvisionQLCore/Sources/ArchiveUtilities.swift
+++ b/ProvisionQLCore/Sources/ArchiveUtilities.swift
@@ -25,19 +25,26 @@ enum ArchiveUtilities {
         return try extractData(from: entry, in: archive)
     }
 
-    /// Extracts data from a specific file in the archive with case-insensitive search
+    /// Extracts data from a specific file in the archive if present.
     /// - Parameters:
     ///   - archive: The ZIP archive
     ///   - path: The path to the file within the archive
+    ///   - caseInsensitive: Whether to fall back to a case-insensitive entry search
     /// - Returns: The extracted data if found, nil otherwise
     /// - Throws: Error if extraction fails
-    static func extractFileOptional(from archive: Archive, path: String) throws -> Data? {
-        // Try exact match first
+    static func extractFileIfPresent(
+        from archive: Archive,
+        path: String,
+        caseInsensitive: Bool = false
+    ) throws -> Data? {
         if let entry = archive[path] {
             return try extractData(from: entry, in: archive)
         }
 
-        // Try case-insensitive search
+        guard caseInsensitive else {
+            return nil
+        }
+
         for entry in archive {
             if entry.path.lowercased() == path.lowercased() {
                 return try extractData(from: entry, in: archive)
@@ -47,17 +54,27 @@ enum ArchiveUtilities {
         return nil
     }
 
-    /// Extracts a specific file to disk with case-insensitive search.
+    /// Extracts a specific file to disk if present.
     /// - Parameters:
     ///   - archive: The ZIP archive
     ///   - path: The path to the file within the archive
     ///   - destinationURL: The destination file URL
+    ///   - caseInsensitive: Whether to fall back to a case-insensitive entry search
     /// - Returns: `true` if the file was found and extracted, otherwise `false`
     /// - Throws: Error if extraction fails
-    static func extractFileOptional(from archive: Archive, path: String, to destinationURL: URL) throws -> Bool {
+    static func extractFileIfPresent(
+        from archive: Archive,
+        path: String,
+        to destinationURL: URL,
+        caseInsensitive: Bool = false
+    ) throws -> Bool {
         if let entry = archive[path] {
             try extract(entry, from: archive, to: destinationURL)
             return true
+        }
+
+        guard caseInsensitive else {
+            return false
         }
 
         for entry in archive {

--- a/ProvisionQLCore/Sources/EntitlementsExtractor.swift
+++ b/ProvisionQLCore/Sources/EntitlementsExtractor.swift
@@ -12,27 +12,8 @@ public enum EntitlementsExtractor {
         extractEntitlementsUsingSecCode(from: appBundleURL) ?? [:]
     }
 
-    static func extractEntitlementsFromArchive(
-        executableData: Data,
-        temporaryDirectory: URL
-    ) -> [String: PlistValue] {
-        // Write executable to temporary file
-        let tempExecutableURL = temporaryDirectory.appendingPathComponent(UUID().uuidString)
-
-        do {
-            try executableData.write(to: tempExecutableURL)
-            defer { try? FileManager.default.removeItem(at: tempExecutableURL) }
-
-            // Make it executable
-            try FileManager.default.setAttributes(
-                [.posixPermissions: 0o755],
-                ofItemAtPath: tempExecutableURL.path
-            )
-
-            return extractEntitlementsUsingSecCode(from: tempExecutableURL) ?? [:]
-        } catch {
-            return [:]
-        }
+    static func extractEntitlements(fromCodeAt codeURL: URL) -> [String: PlistValue] {
+        extractEntitlementsUsingSecCode(from: codeURL) ?? [:]
     }
 }
 

--- a/ProvisionQLCore/Sources/EntitlementsExtractor.swift
+++ b/ProvisionQLCore/Sources/EntitlementsExtractor.swift
@@ -13,7 +13,9 @@ public enum EntitlementsExtractor {
     }
 
     static func extractEntitlements(fromCodeAt codeURL: URL) -> [String: PlistValue] {
-        extractEntitlementsUsingSecCode(from: codeURL) ?? [:]
+        MachOEntitlementsReader.extractEntitlements(from: codeURL)
+            ?? extractEntitlementsUsingSecCode(from: codeURL)
+            ?? [:]
     }
 }
 

--- a/ProvisionQLCore/Sources/IconExtractor.swift
+++ b/ProvisionQLCore/Sources/IconExtractor.swift
@@ -6,124 +6,59 @@
 
 import AppKit
 import Foundation
-import UniformTypeIdentifiers
-import ZIPFoundation
 
 public enum IconExtractor {
     public static func extractIcon(from url: URL) throws -> NSImage? {
+        try extractIconSource(from: url)?.makeImage()
+    }
+
+    public static func extractIconSource(from url: URL) throws -> IconSource? {
         let fileExtension = url.pathExtension.lowercased()
 
         switch fileExtension {
         case "ipa":
-            return try extractFromIPA(url)
+            let source = try IPAAppBundleSource(url: url)
+            return try extractIconSource(from: source)
         case "xcarchive":
-            return try extractFromXCArchive(url)
+            let appBundleURL = try DirectoryAppBundleSource.findAppBundleInXCArchive(at: url)
+            let source = try DirectoryAppBundleSource(bundleURL: appBundleURL)
+            return try extractIconSource(from: source)
         case "appex":
-            return try extractFromAppBundle(url)
+            let source = try DirectoryAppBundleSource(bundleURL: url)
+            return try extractIconSource(from: source)
         default:
             return nil
         }
     }
 }
 
-private extension IconExtractor {
-    static func extractFromIPA(_ url: URL) throws -> NSImage? {
-        let archive = try Archive(url: url, accessMode: .read)
-
+extension IconExtractor {
+    static func extractIconSource(from source: AppBundleSource) throws -> IconSource? {
         let artworkNames = ["iTunesArtwork@3x", "iTunesArtwork@2x", "iTunesArtwork"]
-        for artworkName in artworkNames {
-            if let imageData = try ArchiveUtilities.extractFileOptional(from: archive, path: artworkName),
-               let image = NSImage(data: imageData)
-            {
-                return applyRoundedCorners(to: image)
+        if source.containerKind == .ipa {
+            for artworkName in artworkNames {
+                if let imageData = try source.data(
+                    at: artworkName,
+                    relativeToBundle: false,
+                    caseInsensitive: true
+                ) {
+                    return IconSource(data: imageData)
+                }
             }
         }
 
-        guard let appBundlePath = ArchiveUtilities.findAppBundlePathFlexible(in: archive) else {
-            throw IconExtractionError.appBundleNotFound
-        }
-
-        let infoPlistPath = "\(appBundlePath)/Info.plist"
-        guard let infoPlistData = try ArchiveUtilities.extractFileOptional(from: archive, path: infoPlistPath) else {
-            throw IconExtractionError.infoPlistNotFound
-        }
-
-        let plist = try PlistParser.parse(data: infoPlistData)
+        let plist = try source.infoPlist()
 
         if let iconName = findMainIconName(in: plist),
-           let image = try findIconInArchive(archive: archive, appBundlePath: appBundlePath, iconName: iconName)
+           let iconSource = try findIconSource(iconName: iconName, in: source)
         {
-            return applyRoundedCorners(to: image)
+            return iconSource
         }
 
-        // Try with common prefixes for iOS icons
         let commonPrefixes = ["AppIcon", "Icon"]
         for prefix in commonPrefixes {
-            if let image = try findIconInArchive(archive: archive, appBundlePath: appBundlePath, iconName: prefix) {
-                return applyRoundedCorners(to: image)
-            }
-        }
-
-        return nil
-    }
-
-    static func extractFromXCArchive(_ url: URL) throws -> NSImage? {
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
-              isDirectory.boolValue
-        else {
-            throw IconExtractionError.appBundleNotFound
-        }
-
-        let appsDir = url.appendingPathComponent("Products/Applications")
-
-        // Find the app bundle in Products/Applications/
-        let appBundles = try FileManager.default.contentsOfDirectory(at: appsDir, includingPropertiesForKeys: nil)
-            .filter { $0.pathExtension == "app" }
-
-        guard let appURL = appBundles.first else {
-            throw IconExtractionError.appBundleNotFound
-        }
-
-        return try extractFromAppBundle(appURL)
-    }
-
-    static func extractFromAppBundle(_ url: URL) throws -> NSImage? {
-        let infoPlistURL = url.appendingPathComponent("Contents/Info.plist")
-        if FileManager.default.fileExists(atPath: infoPlistURL.path) {
-            return try extractIconFromBundle(at: url.appendingPathComponent("Contents"), infoPlistURL: infoPlistURL)
-        }
-
-        let iOSInfoPlistURL = url.appendingPathComponent("Info.plist")
-        if FileManager.default.fileExists(atPath: iOSInfoPlistURL.path) {
-            return try extractIconFromBundle(at: url, infoPlistURL: iOSInfoPlistURL)
-        }
-
-        return nil
-    }
-
-    static func extractIconFromBundle(at bundleURL: URL, infoPlistURL: URL) throws -> NSImage? {
-        let plist = try PlistParser.parse(url: infoPlistURL)
-
-        let bundleAction: (String) -> NSImage? = { iconPath in
-            let iconURL = bundleURL.appendingPathComponent(iconPath)
-            if FileManager.default.fileExists(atPath: iconURL.path) {
-                return NSImage(contentsOf: iconURL)
-            }
-            return nil
-        }
-
-        if let iconName = findMainIconName(in: plist),
-           let image = findIcon(iconName: iconName, using: bundleAction)
-        {
-            return applyRoundedCorners(to: image)
-        }
-
-        // Try common prefixes as fallback
-        let commonPrefixes = ["AppIcon", "Icon"]
-        for prefix in commonPrefixes {
-            if let image = findIcon(iconName: prefix, using: bundleAction) {
-                return applyRoundedCorners(to: image)
+            if let iconSource = try findIconSource(iconName: prefix, in: source) {
+                return iconSource
             }
         }
 
@@ -132,7 +67,34 @@ private extension IconExtractor {
 
     // MARK: - Icon Search
 
-    static func findIcon(iconName: String, using action: (String) -> NSImage?) -> NSImage? {
+    static func findIconSource(iconName: String, in source: AppBundleSource) throws -> IconSource? {
+        try findIconData(iconName: iconName) { iconPath in
+            let candidatePaths = if source.bundleStyle == .macOS {
+                [
+                    "Contents/Resources/\(iconPath)",
+                    "Contents/\(iconPath)",
+                    iconPath
+                ]
+            } else {
+                [iconPath]
+            }
+
+            for candidatePath in candidatePaths {
+                if let data = try source.data(
+                    at: candidatePath,
+                    relativeToBundle: true,
+                    caseInsensitive: true
+                ) {
+                    return data
+                }
+            }
+
+            return nil
+        }
+        .map(IconSource.init(data:))
+    }
+
+    static func findIconData(iconName: String, using action: (String) throws -> Data?) rethrows -> Data? {
         let deviceSuffixes = ["~tv", "~ipad", ""]
         let sizeExtensions = ["@3x", "@2x", ""]
         let fileExtensions = [".png", ""]
@@ -141,8 +103,8 @@ private extension IconExtractor {
             for sizeExt in sizeExtensions {
                 for fileExt in fileExtensions {
                     let iconPath = "\(iconName)\(sizeExt)\(deviceSuffix)\(fileExt)"
-                    if let image = action(iconPath) {
-                        return image
+                    if let data = try action(iconPath) {
+                        return data
                     }
                 }
             }
@@ -240,22 +202,6 @@ private extension IconExtractor {
 
         newImage.unlockFocus()
         return newImage
-    }
-
-    // MARK: - Archive Helper Methods
-
-    static func findIconInArchive(archive: Archive, appBundlePath: String, iconName: String) throws -> NSImage? {
-        let unarchiveAction: (String) -> NSImage? = { iconPath in
-            let fullPath = "\(appBundlePath)/\(iconPath)"
-            if let imageData = try? ArchiveUtilities.extractFileOptional(from: archive, path: fullPath),
-               let image = NSImage(data: imageData)
-            {
-                return image
-            }
-            return nil
-        }
-
-        return findIcon(iconName: iconName, using: unarchiveAction)
     }
 }
 

--- a/ProvisionQLCore/Sources/IconExtractor.swift
+++ b/ProvisionQLCore/Sources/IconExtractor.swift
@@ -97,7 +97,7 @@ extension IconExtractor {
     static func findIconData(iconName: String, using action: (String) throws -> Data?) rethrows -> Data? {
         let deviceSuffixes = ["~tv", "~ipad", ""]
         let sizeExtensions = ["@3x", "@2x", ""]
-        let fileExtensions = [".png", ""]
+        let fileExtensions = [".png", ".icns", ""]
 
         for deviceSuffix in deviceSuffixes {
             for sizeExt in sizeExtensions {
@@ -203,11 +203,4 @@ extension IconExtractor {
         newImage.unlockFocus()
         return newImage
     }
-}
-
-// MARK: - Error Types
-
-public enum IconExtractionError: Error {
-    case appBundleNotFound
-    case infoPlistNotFound
 }

--- a/ProvisionQLCore/Sources/IconSource.swift
+++ b/ProvisionQLCore/Sources/IconSource.swift
@@ -1,0 +1,18 @@
+import AppKit
+import Foundation
+
+public struct IconSource: Sendable, Codable, Hashable {
+    public let data: Data
+
+    public init(data: Data) {
+        self.data = data
+    }
+
+    public func makeImage() -> NSImage? {
+        guard let image = NSImage(data: data) else {
+            return nil
+        }
+
+        return IconExtractor.applyRoundedCorners(to: image)
+    }
+}

--- a/ProvisionQLCore/Sources/MachOEntitlementsReader.swift
+++ b/ProvisionQLCore/Sources/MachOEntitlementsReader.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+enum MachOEntitlementsReader {
+    static func extractEntitlements(from executableURL: URL) -> [String: PlistValue]? {
+        guard let data = try? Data(contentsOf: executableURL, options: .mappedIfSafe) else {
+            return nil
+        }
+
+        return extractEntitlements(from: data)
+    }
+
+    static func extractEntitlements(from data: Data) -> [String: PlistValue]? {
+        guard !data.isEmpty else {
+            return nil
+        }
+
+        if let slices = fatSlices(in: data) {
+            for slice in slices {
+                if let entitlements = extractEntitlements(from: data, slice: slice) {
+                    return entitlements
+                }
+            }
+
+            return nil
+        }
+
+        return extractEntitlements(from: data, slice: 0 ..< data.count)
+    }
+}
+
+private extension MachOEntitlementsReader {
+    static let fatMagic: UInt32 = 0xCAFE_BABE
+    static let fatMagic64: UInt32 = 0xCAFE_BABF
+    static let machMagic: UInt32 = 0xFEED_FACE
+    static let machMagic64: UInt32 = 0xFEED_FACF
+    static let machCigam: UInt32 = 0xCEFA_EDFE
+    static let machCigam64: UInt32 = 0xCFFA_EDFE
+    static let lcCodeSignature: UInt32 = 0x1D
+
+    static let csMagicEmbeddedSignature: UInt32 = 0xFADE_0CC0
+    static let csMagicEmbeddedEntitlements: UInt32 = 0xFADE_7171
+    static let csSlotEntitlements: UInt32 = 5
+
+    enum Endianness {
+        case little
+        case big
+    }
+
+    static func fatSlices(in data: Data) -> [Range<Int>]? {
+        guard let magic = data.uint32(at: 0, endianness: .big) else {
+            return nil
+        }
+
+        let isFat64: Bool
+        switch magic {
+        case fatMagic:
+            isFat64 = false
+        case fatMagic64:
+            isFat64 = true
+        default:
+            return nil
+        }
+
+        guard let architectureCount = data.uint32(at: 4, endianness: .big) else {
+            return nil
+        }
+
+        let entrySize = isFat64 ? 32 : 20
+        var slices: [Range<Int>] = []
+
+        for index in 0 ..< Int(architectureCount) {
+            let entryOffset = 8 + index * entrySize
+            let offset: UInt64?
+            let size: UInt64?
+
+            if isFat64 {
+                offset = data.uint64(at: entryOffset + 8, endianness: .big)
+                size = data.uint64(at: entryOffset + 16, endianness: .big)
+            } else {
+                offset = data.uint32(at: entryOffset + 8, endianness: .big).map(UInt64.init)
+                size = data.uint32(at: entryOffset + 12, endianness: .big).map(UInt64.init)
+            }
+
+            guard let offset, let size else {
+                continue
+            }
+
+            guard offset <= UInt64(data.count),
+                  size <= UInt64(data.count) - offset
+            else {
+                continue
+            }
+
+            let lowerBound = Int(offset)
+            let upperBound = Int(offset + size)
+            slices.append(lowerBound ..< upperBound)
+        }
+
+        return slices
+    }
+
+    static func extractEntitlements(from data: Data, slice: Range<Int>) -> [String: PlistValue]? {
+        guard
+            let (endianness, is64Bit) = machHeader(in: data, slice: slice),
+            let loadCommandCount = data.uint32(at: slice.lowerBound + 16, endianness: endianness)
+        else {
+            return nil
+        }
+
+        let headerSize = is64Bit ? 32 : 28
+        var commandOffset = slice.lowerBound + headerSize
+
+        for _ in 0 ..< Int(loadCommandCount) {
+            guard
+                let command = data.uint32(at: commandOffset, endianness: endianness),
+                let commandSize = data.uint32(at: commandOffset + 4, endianness: endianness),
+                commandSize >= 8
+            else {
+                return nil
+            }
+
+            if command == lcCodeSignature,
+               let signatureOffset = data.uint32(at: commandOffset + 8, endianness: endianness),
+               let signatureSize = data.uint32(at: commandOffset + 12, endianness: endianness)
+            {
+                let lowerBound = slice.lowerBound + Int(signatureOffset)
+                let upperBound = lowerBound + Int(signatureSize)
+                guard lowerBound >= slice.lowerBound, upperBound <= slice.upperBound else {
+                    return nil
+                }
+
+                return extractEntitlements(fromCodeSignature: data, range: lowerBound ..< upperBound)
+            }
+
+            commandOffset += Int(commandSize)
+            guard commandOffset <= slice.upperBound else {
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    static func machHeader(in data: Data, slice: Range<Int>) -> (Endianness, Bool)? {
+        guard let littleEndianMagic = data.uint32(at: slice.lowerBound, endianness: .little) else {
+            return nil
+        }
+
+        switch littleEndianMagic {
+        case machMagic:
+            return (.little, false)
+        case machMagic64:
+            return (.little, true)
+        case machCigam:
+            return (.big, false)
+        case machCigam64:
+            return (.big, true)
+        default:
+            return nil
+        }
+    }
+
+    static func extractEntitlements(fromCodeSignature data: Data, range: Range<Int>) -> [String: PlistValue]? {
+        guard let magic = data.uint32(at: range.lowerBound, endianness: .big) else {
+            return nil
+        }
+
+        if magic == csMagicEmbeddedEntitlements {
+            return parseEntitlementsBlob(in: data, at: range.lowerBound, limit: range.upperBound)
+        }
+
+        guard magic == csMagicEmbeddedSignature,
+              let count = data.uint32(at: range.lowerBound + 8, endianness: .big)
+        else {
+            return nil
+        }
+
+        for index in 0 ..< Int(count) {
+            let entryOffset = range.lowerBound + 12 + index * 8
+            guard
+                let type = data.uint32(at: entryOffset, endianness: .big),
+                let blobOffset = data.uint32(at: entryOffset + 4, endianness: .big)
+            else {
+                continue
+            }
+
+            let absoluteBlobOffset = range.lowerBound + Int(blobOffset)
+            guard absoluteBlobOffset < range.upperBound else {
+                continue
+            }
+
+            if type == csSlotEntitlements,
+               let entitlements = parseEntitlementsBlob(in: data, at: absoluteBlobOffset, limit: range.upperBound)
+            {
+                return entitlements
+            }
+        }
+
+        return nil
+    }
+
+    static func parseEntitlementsBlob(in data: Data, at offset: Int, limit: Int) -> [String: PlistValue]? {
+        guard
+            data.uint32(at: offset, endianness: .big) == csMagicEmbeddedEntitlements,
+            let length = data.uint32(at: offset + 4, endianness: .big)
+        else {
+            return nil
+        }
+
+        let plistStart = offset + 8
+        let plistEnd = offset + Int(length)
+        guard plistStart <= plistEnd, plistEnd <= limit else {
+            return nil
+        }
+
+        let plistData = data.subdata(in: plistStart ..< plistEnd)
+        guard
+            let plist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil),
+            let dictionary = plist as? [String: Any],
+            let value = PlistValue.from(value: dictionary),
+            case .dictionary(let entitlements) = value
+        else {
+            return nil
+        }
+
+        return entitlements
+    }
+}
+
+private extension Data {
+    var bounds: Range<Int> {
+        startIndex ..< endIndex
+    }
+
+    func uint32(at offset: Int, endianness: MachOEntitlementsReader.Endianness) -> UInt32? {
+        guard bounds.contains(offset), offset + 4 <= count else {
+            return nil
+        }
+
+        let value = self[offset ..< offset + 4].reduce(UInt32(0)) { partialResult, byte in
+            partialResult << 8 | UInt32(byte)
+        }
+
+        return switch endianness {
+        case .big:
+            value
+        case .little:
+            value.byteSwapped
+        }
+    }
+
+    func uint64(at offset: Int, endianness: MachOEntitlementsReader.Endianness) -> UInt64? {
+        guard bounds.contains(offset), offset + 8 <= count else {
+            return nil
+        }
+
+        let value = self[offset ..< offset + 8].reduce(UInt64(0)) { partialResult, byte in
+            partialResult << 8 | UInt64(byte)
+        }
+
+        return switch endianness {
+        case .big:
+            value
+        case .little:
+            value.byteSwapped
+        }
+    }
+}

--- a/ProvisionQLCore/Sources/MachOEntitlementsReader.swift
+++ b/ProvisionQLCore/Sources/MachOEntitlementsReader.swift
@@ -66,9 +66,15 @@ private extension MachOEntitlementsReader {
         }
 
         let entrySize = isFat64 ? 32 : 20
+        let architectureCountInt = Int(architectureCount)
+        let maximumArchitectureCount = (data.count - 8) / entrySize
+        guard architectureCountInt <= maximumArchitectureCount else {
+            return nil
+        }
+
         var slices: [Range<Int>] = []
 
-        for index in 0 ..< Int(architectureCount) {
+        for index in 0 ..< architectureCountInt {
             let entryOffset = 8 + index * entrySize
             let offset: UInt64?
             let size: UInt64?
@@ -101,6 +107,8 @@ private extension MachOEntitlementsReader {
 
     static func extractEntitlements(from data: Data, slice: Range<Int>) -> [String: PlistValue]? {
         guard
+            data.bounds.contains(slice.lowerBound),
+            slice.upperBound <= data.count,
             let (endianness, is64Bit) = machHeader(in: data, slice: slice),
             let loadCommandCount = data.uint32(at: slice.lowerBound + 16, endianness: endianness)
         else {
@@ -109,9 +117,18 @@ private extension MachOEntitlementsReader {
 
         let headerSize = is64Bit ? 32 : 28
         var commandOffset = slice.lowerBound + headerSize
+        guard commandOffset <= slice.upperBound else {
+            return nil
+        }
+
+        let maximumLoadCommandCount = (slice.upperBound - commandOffset) / 8
+        guard Int(loadCommandCount) <= maximumLoadCommandCount else {
+            return nil
+        }
 
         for _ in 0 ..< Int(loadCommandCount) {
             guard
+                commandOffset + 8 <= slice.upperBound,
                 let command = data.uint32(at: commandOffset, endianness: endianness),
                 let commandSize = data.uint32(at: commandOffset + 4, endianness: endianness),
                 commandSize >= 8
@@ -119,23 +136,32 @@ private extension MachOEntitlementsReader {
                 return nil
             }
 
-            if command == lcCodeSignature,
-               let signatureOffset = data.uint32(at: commandOffset + 8, endianness: endianness),
-               let signatureSize = data.uint32(at: commandOffset + 12, endianness: endianness)
-            {
-                let lowerBound = slice.lowerBound + Int(signatureOffset)
-                let upperBound = lowerBound + Int(signatureSize)
-                guard lowerBound >= slice.lowerBound, upperBound <= slice.upperBound else {
+            let commandSizeInt = Int(commandSize)
+            guard commandSizeInt <= slice.upperBound - commandOffset else {
+                return nil
+            }
+
+            if command == lcCodeSignature {
+                guard commandSizeInt >= 16,
+                      let signatureOffset = data.uint32(at: commandOffset + 8, endianness: endianness),
+                      let signatureSize = data.uint32(at: commandOffset + 12, endianness: endianness)
+                else {
                     return nil
                 }
 
+                let sliceSize = UInt64(slice.upperBound - slice.lowerBound)
+                guard UInt64(signatureOffset) <= sliceSize,
+                      UInt64(signatureSize) <= sliceSize - UInt64(signatureOffset)
+                else {
+                    return nil
+                }
+
+                let lowerBound = slice.lowerBound + Int(signatureOffset)
+                let upperBound = lowerBound + Int(signatureSize)
                 return extractEntitlements(fromCodeSignature: data, range: lowerBound ..< upperBound)
             }
 
-            commandOffset += Int(commandSize)
-            guard commandOffset <= slice.upperBound else {
-                return nil
-            }
+            commandOffset += commandSizeInt
         }
 
         return nil

--- a/ProvisionQLCore/Sources/MachOEntitlementsReader.swift
+++ b/ProvisionQLCore/Sources/MachOEntitlementsReader.swift
@@ -35,11 +35,11 @@ private extension MachOEntitlementsReader {
     static let machMagic64: UInt32 = 0xFEED_FACF
     static let machCigam: UInt32 = 0xCEFA_EDFE
     static let machCigam64: UInt32 = 0xCFFA_EDFE
-    static let lcCodeSignature: UInt32 = 0x1D
+    static let lcCodeSignature: UInt32 = 0x1D // LC_CODE_SIGNATURE
 
-    static let csMagicEmbeddedSignature: UInt32 = 0xFADE_0CC0
-    static let csMagicEmbeddedEntitlements: UInt32 = 0xFADE_7171
-    static let csSlotEntitlements: UInt32 = 5
+    static let csMagicEmbeddedSignature: UInt32 = 0xFADE_0CC0 // CSMAGIC_EMBEDDED_SIGNATURE
+    static let csMagicEmbeddedEntitlements: UInt32 = 0xFADE_7171 // CSMAGIC_EMBEDDED_ENTITLEMENTS
+    static let csSlotEntitlements: UInt32 = 5 // CSSLOT_ENTITLEMENTS
 
     enum Endianness {
         case little

--- a/ProvisionQLCore/Sources/PlistParser.swift
+++ b/ProvisionQLCore/Sources/PlistParser.swift
@@ -57,7 +57,6 @@ enum PlistParser {
             bundleIdentifier: bundleIdentifier,
             version: version,
             buildNumber: buildNumber,
-            icon: nil,
             embeddedProvisioningProfile: nil,
             entitlements: [:],
             deviceFamily: deviceFamily,

--- a/ProvisionQLCore/Sources/ProvisioningProfileExtractor.swift
+++ b/ProvisionQLCore/Sources/ProvisioningProfileExtractor.swift
@@ -5,59 +5,20 @@
 //  Created by Evgeny Aleksandrov
 
 import Foundation
-import ZIPFoundation
 
 /// Utilities for extracting embedded provisioning profiles
 enum ProvisioningProfileExtractor {
-    private static let embeddedProvisioningProfilePaths = [
+    static let embeddedProvisioningProfilePaths = [
         "Contents/embedded.provisionprofile",
         "embedded.mobileprovision",
         "embedded.provisionprofile"
     ]
 
-    // MARK: - Archive Extraction
-
-    /// Extracts an embedded provisioning profile from an archive
-    /// - Parameters:
-    ///   - archive: The ZIP archive
-    ///   - appBundlePath: The path to the app bundle within the archive
-    /// - Returns: The extraction result
-    static func extractFromArchive(_ archive: Archive, appBundlePath: String) -> EmbeddedProvisioningProfileExtraction {
-        for relativePath in embeddedProvisioningProfilePaths {
-            let profilePath = archivePath(appBundlePath: appBundlePath, relativePath: relativePath)
-            if let profileData = try? ArchiveUtilities.extractFile(from: archive, path: profilePath) {
-                return parseProfileData(profileData)
-            }
-        }
-
-        return .missing
-    }
-
-    // MARK: - Directory Extraction
-
-    /// Extracts an embedded provisioning profile from a directory
-    /// - Parameter directoryURL: The URL to the app bundle directory
-    /// - Returns: The extraction result
-    static func extractFromDirectory(_ directoryURL: URL) -> EmbeddedProvisioningProfileExtraction {
-        for relativePath in embeddedProvisioningProfilePaths {
-            let profileURL = directoryURL.appendingPathComponent(relativePath)
-
-            guard FileManager.default.fileExists(atPath: profileURL.path) else {
-                continue
-            }
-
-            do {
-                let provisioningInfo = try ProvisioningParser.parse(profileURL)
-                return .success(provisioningInfo)
-            } catch {
-                return .failure(error)
-            }
-        }
-
-        return .missing
-    }
-
     // MARK: - Helper Methods
+
+    static func extract(from profileData: Data) -> EmbeddedProvisioningProfileExtraction {
+        parseProfileData(profileData)
+    }
 
     private static func parseProfileData(_ profileData: Data) -> EmbeddedProvisioningProfileExtraction {
         let tempURL = createTemporaryURL()
@@ -71,14 +32,6 @@ enum ProvisioningProfileExtractor {
         } catch {
             return .failure(error)
         }
-    }
-
-    private static func archivePath(appBundlePath: String, relativePath: String) -> String {
-        if appBundlePath.hasSuffix("/") {
-            return appBundlePath + relativePath
-        }
-
-        return appBundlePath + "/" + relativePath
     }
 
     /// Creates a temporary URL for storing provisioning profile data

--- a/ProvisionQLCore/Tests/AppArchiveTests.swift
+++ b/ProvisionQLCore/Tests/AppArchiveTests.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Evgeny Aleksandrov
 
-import AppKit
 import Foundation
 @testable import ProvisionQLCore
 import Testing
@@ -25,7 +24,6 @@ struct AppArchiveTests {
     struct AppInfoTests {
         @Test("AppInfo initialization with all parameters")
         func appInfoInitialization() throws {
-            let mockIcon = NSImage(size: NSSize(width: 64, height: 64))
             let mockProfile = try createMockProvisioningInfo()
 
             let appInfo = AppInfo(
@@ -33,7 +31,6 @@ struct AppArchiveTests {
                 bundleIdentifier: "com.test.app",
                 version: "1.0.0",
                 buildNumber: "100",
-                icon: mockIcon,
                 embeddedProvisioningProfile: mockProfile,
                 deviceFamily: ["iPhone", "iPad"],
                 minimumOSVersion: "15.0",
@@ -44,7 +41,6 @@ struct AppArchiveTests {
             #expect(appInfo.bundleIdentifier == "com.test.app")
             #expect(appInfo.version == "1.0.0")
             #expect(appInfo.buildNumber == "100")
-            #expect(appInfo.icon != nil)
             #expect(appInfo.embeddedProvisioningProfile?.name == mockProfile.name)
             #expect(appInfo.deviceFamily == ["iPhone", "iPad"])
             #expect(appInfo.minimumOSVersion == "15.0")

--- a/ProvisionQLCore/Tests/CoreTests.swift
+++ b/ProvisionQLCore/Tests/CoreTests.swift
@@ -484,6 +484,27 @@ struct CoreTests {
         }
     }
 
+    @Suite("Mach-O Entitlements Tests")
+    struct MachOEntitlementsTests {
+        @Test("Extracts embedded entitlements from code signature")
+        func extractsEmbeddedEntitlements() throws {
+            let executableData = try createMachOExecutableData(entitlements: [
+                "application-identifier": "ABCDE12345.com.example.app",
+                "get-task-allow": true
+            ])
+            let executableURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+            defer { try? FileManager.default.removeItem(at: executableURL) }
+
+            try executableData.write(to: executableURL)
+
+            let entitlements = EntitlementsExtractor.extractEntitlements(fromCodeAt: executableURL)
+
+            #expect(entitlements["application-identifier"] == .string("ABCDE12345.com.example.app"))
+            #expect(entitlements["get-task-allow"] == .bool(true))
+        }
+    }
+
     @Suite("RawProfile Tests", .tags(.models))
     struct RawProfileTests {
         @Test("RawProfile Codable conformance")
@@ -524,6 +545,62 @@ struct CoreTests {
             #expect(decodedProfile.ProvisionedDevices == originalProfile.ProvisionedDevices)
             #expect(decodedProfile.ProvisionsAllDevices == originalProfile.ProvisionsAllDevices)
             #expect(decodedProfile.Platform == originalProfile.Platform)
+        }
+    }
+}
+
+private func createMachOExecutableData(entitlements: [String: Any]) throws -> Data {
+    let plistData = try PropertyListSerialization.data(
+        fromPropertyList: entitlements,
+        format: .xml,
+        options: 0
+    )
+
+    var entitlementsBlob = Data()
+    entitlementsBlob.appendBigEndianUInt32(0xFADE_7171)
+    entitlementsBlob.appendBigEndianUInt32(UInt32(8 + plistData.count))
+    entitlementsBlob.append(plistData)
+
+    var codeSignature = Data()
+    codeSignature.appendBigEndianUInt32(0xFADE_0CC0)
+    codeSignature.appendBigEndianUInt32(UInt32(20 + entitlementsBlob.count))
+    codeSignature.appendBigEndianUInt32(1)
+    codeSignature.appendBigEndianUInt32(5)
+    codeSignature.appendBigEndianUInt32(20)
+    codeSignature.append(entitlementsBlob)
+
+    let codeSignatureOffset: UInt32 = 48
+
+    var executable = Data()
+    executable.appendLittleEndianUInt32(0xFEED_FACF)
+    executable.appendLittleEndianUInt32(0x0100_000C)
+    executable.appendLittleEndianUInt32(0)
+    executable.appendLittleEndianUInt32(2)
+    executable.appendLittleEndianUInt32(1)
+    executable.appendLittleEndianUInt32(16)
+    executable.appendLittleEndianUInt32(0)
+    executable.appendLittleEndianUInt32(0)
+    executable.appendLittleEndianUInt32(0x1D)
+    executable.appendLittleEndianUInt32(16)
+    executable.appendLittleEndianUInt32(codeSignatureOffset)
+    executable.appendLittleEndianUInt32(UInt32(codeSignature.count))
+    executable.append(codeSignature)
+
+    return executable
+}
+
+private extension Data {
+    mutating func appendLittleEndianUInt32(_ value: UInt32) {
+        var littleEndianValue = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndianValue) { buffer in
+            append(contentsOf: buffer)
+        }
+    }
+
+    mutating func appendBigEndianUInt32(_ value: UInt32) {
+        var bigEndianValue = value.bigEndian
+        Swift.withUnsafeBytes(of: &bigEndianValue) { buffer in
+            append(contentsOf: buffer)
         }
     }
 }

--- a/ProvisionQLCore/Tests/CoreTests.swift
+++ b/ProvisionQLCore/Tests/CoreTests.swift
@@ -503,6 +503,25 @@ struct CoreTests {
             #expect(entitlements["application-identifier"] == .string("ABCDE12345.com.example.app"))
             #expect(entitlements["get-task-allow"] == .bool(true))
         }
+
+        @Test("Rejects fat headers with impossible architecture counts")
+        func rejectsImpossibleFatArchitectureCount() {
+            var data = Data()
+            data.appendBigEndianUInt32(0xCAFE_BABE)
+            data.appendBigEndianUInt32(UInt32.max)
+
+            #expect(MachOEntitlementsReader.extractEntitlements(from: data) == nil)
+        }
+
+        @Test("Rejects short code signature load commands")
+        func rejectsShortCodeSignatureLoadCommand() {
+            var data = createMachOHeader(loadCommandCount: 1, loadCommandsSize: 12)
+            data.appendLittleEndianUInt32(0x1D)
+            data.appendLittleEndianUInt32(12)
+            data.appendLittleEndianUInt32(0)
+
+            #expect(MachOEntitlementsReader.extractEntitlements(from: data) == nil)
+        }
     }
 
     @Suite("RawProfile Tests", .tags(.models))
@@ -549,6 +568,19 @@ struct CoreTests {
     }
 }
 
+private func createMachOHeader(loadCommandCount: UInt32, loadCommandsSize: UInt32) -> Data {
+    var executable = Data()
+    executable.appendLittleEndianUInt32(0xFEED_FACF)
+    executable.appendLittleEndianUInt32(0x0100_000C)
+    executable.appendLittleEndianUInt32(0)
+    executable.appendLittleEndianUInt32(2)
+    executable.appendLittleEndianUInt32(loadCommandCount)
+    executable.appendLittleEndianUInt32(loadCommandsSize)
+    executable.appendLittleEndianUInt32(0)
+    executable.appendLittleEndianUInt32(0)
+    return executable
+}
+
 private func createMachOExecutableData(entitlements: [String: Any]) throws -> Data {
     let plistData = try PropertyListSerialization.data(
         fromPropertyList: entitlements,
@@ -571,15 +603,7 @@ private func createMachOExecutableData(entitlements: [String: Any]) throws -> Da
 
     let codeSignatureOffset: UInt32 = 48
 
-    var executable = Data()
-    executable.appendLittleEndianUInt32(0xFEED_FACF)
-    executable.appendLittleEndianUInt32(0x0100_000C)
-    executable.appendLittleEndianUInt32(0)
-    executable.appendLittleEndianUInt32(2)
-    executable.appendLittleEndianUInt32(1)
-    executable.appendLittleEndianUInt32(16)
-    executable.appendLittleEndianUInt32(0)
-    executable.appendLittleEndianUInt32(0)
+    var executable = createMachOHeader(loadCommandCount: 1, loadCommandsSize: 16)
     executable.appendLittleEndianUInt32(0x1D)
     executable.appendLittleEndianUInt32(16)
     executable.appendLittleEndianUInt32(codeSignatureOffset)


### PR DESCRIPTION
Refactors archive parsing around a shared bundle source abstraction.

- Split `AppInfo` from icon image state
- Centralize IPA, xcarchive, and appex bundle access
- Stream IPA executable extraction instead of loading it all into memory
- Move preview parsing into a model and precompute file info
- Parse Mach-O entitlements directly, with Security.framework fallback
- Add macOS `.icns` icon lookup and tighter bundle-source edge cases