### PR TITLE
Show profile type and signature status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improves provisioning profile validation and in-preview error reporting
 * Fixes certificate expiration parsing
 * Preserves unknown provisioning platforms and nested entitlement values
+* Shows explicit provisioning profile type and signature status
 * Fixes parsing for macOS `.xcarchive` and `.appex` bundles
 * Shows archive parsing failures in the preview
 

--- a/Preview/Views/ProvisioningPreviewView.swift
+++ b/Preview/Views/ProvisioningPreviewView.swift
@@ -97,6 +97,20 @@ extension ProvisioningInfo.ProfileType {
         case .adHoc: .purple
         case .appStore: UIConstants.Color.validGreen
         case .enterprise: .orange
+        case .developerID: .indigo
+        case .directDistribution: .indigo
+        }
+    }
+}
+
+extension ProvisioningInfo.SignerStatus {
+    var color: Color {
+        switch self {
+        case .signedByAppleWWDR: UIConstants.Color.validGreen
+        case .signed: .indigo
+        case .unsigned: .orange
+        case .invalidSignature, .invalidCertificate: .red
+        case .needsDetachedContent, .unknown: .secondary
         }
     }
 }

--- a/Preview/Views/ProvisioningProfileHeader.swift
+++ b/Preview/Views/ProvisioningProfileHeader.swift
@@ -40,6 +40,13 @@ struct ProvisioningProfileHeader: View {
                     color: profile.expirationStatus.color
                 )
 
+                if profile.signerStatus != .unknown {
+                    StatusBadge(
+                        text: profile.signerStatus.rawValue,
+                        color: profile.signerStatus.color
+                    )
+                }
+
                 if !profile.certificates.isEmpty {
                     StatusBadge(
                         text: "\(profile.certificates.count) certs",

--- a/ProvisionQLCore/Sources/ProvisioningInfo.swift
+++ b/ProvisionQLCore/Sources/ProvisioningInfo.swift
@@ -246,12 +246,13 @@ private extension ProvisioningInfo.ProfileType {
         }
 
         switch profileType.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
-        case "IOS_APP_DEVELOPMENT", "MAC_APP_DEVELOPMENT", "TVOS_APP_DEVELOPMENT",
+        case "IOS_APP_DEVELOPMENT", "MAC_APP_DEVELOPMENT", "TVOS_APP_DEVELOPMENT", "VISIONOS_APP_DEVELOPMENT",
+             "WATCHOS_APP_DEVELOPMENT",
              "MAC_CATALYST_APP_DEVELOPMENT":
             self = .development
-        case "IOS_APP_ADHOC", "TVOS_APP_ADHOC":
+        case "IOS_APP_ADHOC", "TVOS_APP_ADHOC", "VISIONOS_APP_ADHOC":
             self = .adHoc
-        case "IOS_APP_STORE", "MAC_APP_STORE", "TVOS_APP_STORE", "MAC_CATALYST_APP_STORE":
+        case "IOS_APP_STORE", "MAC_APP_STORE", "TVOS_APP_STORE", "VISIONOS_APP_STORE", "MAC_CATALYST_APP_STORE":
             self = .appStore
         case "IOS_APP_INHOUSE", "TVOS_APP_INHOUSE":
             self = .enterprise

--- a/ProvisionQLCore/Sources/ProvisioningInfo.swift
+++ b/ProvisionQLCore/Sources/ProvisioningInfo.swift
@@ -24,6 +24,23 @@ public struct ProvisioningInfo: Sendable, Codable, Hashable {
     public let platform: [Platform]
     public let diagnostics: [ProvisioningDiagnostic]
 
+    private enum CodingKeys: String, CodingKey {
+        case uuid
+        case name
+        case teamName
+        case teamID
+        case appID
+        case expirationDate
+        case creationDate
+        case devices
+        case certificates
+        case entitlements
+        case profileType
+        case signerStatus
+        case platform
+        case diagnostics
+    }
+
     @frozen
     public enum ProfileType: String, Codable, Sendable {
         case development = "Development"
@@ -101,6 +118,25 @@ public struct ProvisioningInfo: Sendable, Codable, Hashable {
         }
 
         return .valid
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        uuid = try container.decode(String.self, forKey: .uuid)
+        name = try container.decode(String.self, forKey: .name)
+        teamName = try container.decode(String.self, forKey: .teamName)
+        teamID = try container.decode(String.self, forKey: .teamID)
+        appID = try container.decode(String.self, forKey: .appID)
+        expirationDate = try container.decode(Date.self, forKey: .expirationDate)
+        creationDate = try container.decode(Date.self, forKey: .creationDate)
+        devices = try container.decodeIfPresent([String].self, forKey: .devices)
+        certificates = try container.decode([CertificateInfo].self, forKey: .certificates)
+        entitlements = try container.decode([String: PlistValue].self, forKey: .entitlements)
+        profileType = try container.decode(ProfileType.self, forKey: .profileType)
+        signerStatus = try container.decodeIfPresent(SignerStatus.self, forKey: .signerStatus) ?? .unknown
+        platform = try container.decode([Platform].self, forKey: .platform)
+        diagnostics = try container.decode([ProvisioningDiagnostic].self, forKey: .diagnostics)
     }
 }
 

--- a/ProvisionQLCore/Sources/ProvisioningInfo.swift
+++ b/ProvisionQLCore/Sources/ProvisioningInfo.swift
@@ -29,6 +29,8 @@ public struct ProvisioningInfo: Sendable, Codable, Hashable {
         case adHoc = "Distribution (Ad Hoc)"
         case appStore = "Distribution (App Store)"
         case enterprise = "Enterprise"
+        case developerID = "Developer ID"
+        case directDistribution = "Direct Distribution"
     }
 
     @frozen
@@ -136,29 +138,7 @@ extension ProvisioningInfo {
         }
         certificates = certificateInfos
 
-        // Determine profile type
-        let hasDevices = profile.ProvisionedDevices != nil
-        let getTaskAllow: Bool = {
-            if case .bool(let value) = entitlements["get-task-allow"] {
-                return value
-            }
-            return false
-        }()
-        let isEnterprise = profile.ProvisionsAllDevices ?? false
-
-        if hasDevices {
-            if getTaskAllow {
-                profileType = .development
-            } else {
-                profileType = .adHoc
-            }
-        } else {
-            if isEnterprise {
-                profileType = .enterprise
-            } else {
-                profileType = .appStore
-            }
-        }
+        profileType = Self.profileType(for: profile, entitlements: entitlements)
 
         // Determine platform
         let platforms = profile.Platform?.compactMap { platformString in
@@ -222,5 +202,52 @@ extension ProvisioningInfo {
 
     private static func firstNonEmpty(_ values: [String]?) -> String? {
         values?.compactMap(nonEmpty).first
+    }
+
+    private static func profileType(for profile: RawProfile, entitlements: [String: PlistValue]) -> ProfileType {
+        if let explicitType = ProfileType(profile.ProfileType) {
+            return explicitType
+        }
+
+        let hasDevices = profile.ProvisionedDevices != nil
+        let getTaskAllow: Bool = {
+            if case .bool(let value) = entitlements["get-task-allow"] {
+                return value
+            }
+            return false
+        }()
+        let isEnterprise = profile.ProvisionsAllDevices ?? false
+
+        if hasDevices {
+            return getTaskAllow ? .development : .adHoc
+        } else {
+            return isEnterprise ? .enterprise : .appStore
+        }
+    }
+}
+
+private extension ProvisioningInfo.ProfileType {
+    init?(_ profileType: String?) {
+        guard let profileType else {
+            return nil
+        }
+
+        switch profileType.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
+        case "IOS_APP_DEVELOPMENT", "MAC_APP_DEVELOPMENT", "TVOS_APP_DEVELOPMENT",
+             "MAC_CATALYST_APP_DEVELOPMENT":
+            self = .development
+        case "IOS_APP_ADHOC", "TVOS_APP_ADHOC":
+            self = .adHoc
+        case "IOS_APP_STORE", "MAC_APP_STORE", "TVOS_APP_STORE", "MAC_CATALYST_APP_STORE":
+            self = .appStore
+        case "IOS_APP_INHOUSE", "TVOS_APP_INHOUSE":
+            self = .enterprise
+        case "DEVELOPER_ID", "MAC_APP_DEVELOPER_ID":
+            self = .developerID
+        case "MAC_APP_DIRECT", "MAC_CATALYST_APP_DIRECT", "DIRECT_DISTRIBUTION", "MAC_APP_DIRECT_DISTRIBUTION":
+            self = .directDistribution
+        default:
+            return nil
+        }
     }
 }

--- a/ProvisionQLCore/Sources/ProvisioningInfo.swift
+++ b/ProvisionQLCore/Sources/ProvisioningInfo.swift
@@ -20,6 +20,7 @@ public struct ProvisioningInfo: Sendable, Codable, Hashable {
     public let certificates: [CertificateInfo]
     public let entitlements: [String: PlistValue]
     public let profileType: ProfileType
+    public let signerStatus: SignerStatus
     public let platform: [Platform]
     public let diagnostics: [ProvisioningDiagnostic]
 
@@ -31,6 +32,17 @@ public struct ProvisioningInfo: Sendable, Codable, Hashable {
         case enterprise = "Enterprise"
         case developerID = "Developer ID"
         case directDistribution = "Direct Distribution"
+    }
+
+    @frozen
+    public enum SignerStatus: String, Codable, Sendable, Hashable {
+        case signedByAppleWWDR = "Signed by Apple WWDR"
+        case signed = "Signed"
+        case unsigned = "Unsigned"
+        case invalidSignature = "Invalid Signature"
+        case invalidCertificate = "Invalid Certificate"
+        case needsDetachedContent = "Needs Detached Content"
+        case unknown = "Signature Unknown"
     }
 
     @frozen
@@ -93,7 +105,7 @@ public struct ProvisioningInfo: Sendable, Codable, Hashable {
 }
 
 extension ProvisioningInfo {
-    init(from profile: RawProfile) throws {
+    init(from profile: RawProfile, signerStatus: SignerStatus = .unknown) throws {
         let missingFields = Self.missingRequiredFields(in: profile)
         guard
             missingFields.isEmpty,
@@ -114,6 +126,7 @@ extension ProvisioningInfo {
         self.teamName = teamName
         self.teamID = teamID
         self.appID = appID
+        self.signerStatus = signerStatus
         self.expirationDate = expirationDate
         self.creationDate = creationDate
         devices = profile.ProvisionedDevices

--- a/ProvisionQLCore/Sources/ProvisioningParser.swift
+++ b/ProvisionQLCore/Sources/ProvisioningParser.swift
@@ -74,8 +74,6 @@ private extension ProvisioningParser {
 
         for signerIndex in 0 ..< signerCount {
             var cmsSignerStatus = CMSSignerStatus.unsigned
-            var trust: SecTrust?
-            var certVerifyResult = errSecSuccess
 
             guard CMSDecoderCopySignerStatus(
                 cmsDecoder,
@@ -83,8 +81,8 @@ private extension ProvisioningParser {
                 policy,
                 true,
                 &cmsSignerStatus,
-                &trust,
-                &certVerifyResult
+                nil,
+                nil
             ) == errSecSuccess else {
                 continue
             }

--- a/ProvisionQLCore/Sources/ProvisioningParser.swift
+++ b/ProvisionQLCore/Sources/ProvisioningParser.swift
@@ -10,7 +10,24 @@ import Security
 public enum ProvisioningParser {
     public static func parse(_ url: URL) throws -> ProvisioningInfo {
         let fileData = try Data(contentsOf: url)
+        return try parse(fileData)
+    }
 
+    public static func parse(_ data: Data) throws -> ProvisioningInfo {
+        let decodedCMS = try decodeCMS(data)
+        let profile = try PropertyListDecoder().decode(RawProfile.self, from: decodedCMS.plistData)
+
+        return try ProvisioningInfo(from: profile, signerStatus: decodedCMS.signerStatus)
+    }
+
+    public static func fetchBadgeInfo(from url: URL) throws -> BadgeInfo {
+        let info = try parse(url)
+        return BadgeInfo(from: info)
+    }
+}
+
+private extension ProvisioningParser {
+    static func decodeCMS(_ fileData: Data) throws -> (plistData: Data, signerStatus: ProvisioningInfo.SignerStatus) {
         var decoder: CMSDecoder?
         guard CMSDecoderCreate(&decoder) == errSecSuccess,
               let cmsDecoder = decoder
@@ -18,7 +35,15 @@ public enum ProvisioningParser {
             throw ParsingError.cmsDecodingFailed
         }
 
-        guard CMSDecoderUpdateMessage(cmsDecoder, Array(fileData), fileData.count) == errSecSuccess,
+        let updateStatus = fileData.withUnsafeBytes { buffer -> OSStatus in
+            guard let baseAddress = buffer.baseAddress else {
+                return errSecParam
+            }
+
+            return CMSDecoderUpdateMessage(cmsDecoder, baseAddress, fileData.count)
+        }
+
+        guard updateStatus == errSecSuccess,
               CMSDecoderFinalizeMessage(cmsDecoder) == errSecSuccess
         else {
             throw ParsingError.cmsDecodingFailed
@@ -31,13 +56,72 @@ public enum ProvisioningParser {
             throw ParsingError.plistExtractionFailed
         }
 
-        let profile = try PropertyListDecoder().decode(RawProfile.self, from: plistData)
-
-        return try ProvisioningInfo(from: profile)
+        return (plistData, signerStatus(for: cmsDecoder))
     }
 
-    public static func fetchBadgeInfo(from url: URL) throws -> BadgeInfo {
-        let info = try parse(url)
-        return BadgeInfo(from: info)
+    static func signerStatus(for cmsDecoder: CMSDecoder) -> ProvisioningInfo.SignerStatus {
+        var signerCount = 0
+        guard CMSDecoderGetNumSigners(cmsDecoder, &signerCount) == errSecSuccess else {
+            return .unknown
+        }
+
+        guard signerCount > 0 else {
+            return .unsigned
+        }
+
+        let policy = SecPolicyCreateBasicX509()
+        var bestStatus = ProvisioningInfo.SignerStatus.unknown
+
+        for signerIndex in 0 ..< signerCount {
+            var cmsSignerStatus = CMSSignerStatus.unsigned
+            var trust: SecTrust?
+            var certVerifyResult = errSecSuccess
+
+            guard CMSDecoderCopySignerStatus(
+                cmsDecoder,
+                signerIndex,
+                policy,
+                true,
+                &cmsSignerStatus,
+                &trust,
+                &certVerifyResult
+            ) == errSecSuccess else {
+                continue
+            }
+
+            switch cmsSignerStatus {
+            case .valid:
+                if signerIsAppleWWDR(cmsDecoder, signerIndex: signerIndex) {
+                    return .signedByAppleWWDR
+                }
+                bestStatus = .signed
+            case .unsigned:
+                bestStatus = .unsigned
+            case .invalidSignature:
+                return .invalidSignature
+            case .invalidCert:
+                return .invalidCertificate
+            case .needsDetachedContent:
+                bestStatus = .needsDetachedContent
+            case .invalidIndex:
+                continue
+            default:
+                continue
+            }
+        }
+
+        return bestStatus
+    }
+
+    static func signerIsAppleWWDR(_ cmsDecoder: CMSDecoder, signerIndex: Int) -> Bool {
+        var signerCertificate: SecCertificate?
+        guard CMSDecoderCopySignerCert(cmsDecoder, signerIndex, &signerCertificate) == errSecSuccess,
+              let signerCertificate
+        else {
+            return false
+        }
+
+        let summary = SecCertificateCopySubjectSummary(signerCertificate) as String? ?? ""
+        return summary.localizedCaseInsensitiveContains("Apple Worldwide Developer Relations")
     }
 }

--- a/ProvisionQLCore/Sources/ProvisioningProfileExtractor.swift
+++ b/ProvisionQLCore/Sources/ProvisioningProfileExtractor.swift
@@ -17,28 +17,12 @@ enum ProvisioningProfileExtractor {
     // MARK: - Helper Methods
 
     static func extract(from profileData: Data) -> EmbeddedProvisioningProfileExtraction {
-        parseProfileData(profileData)
-    }
-
-    private static func parseProfileData(_ profileData: Data) -> EmbeddedProvisioningProfileExtraction {
-        let tempURL = createTemporaryURL()
-
         do {
-            try profileData.write(to: tempURL)
-            defer { try? FileManager.default.removeItem(at: tempURL) }
-
-            let provisioningInfo = try ProvisioningParser.parse(tempURL)
+            let provisioningInfo = try ProvisioningParser.parse(profileData)
             return .success(provisioningInfo)
         } catch {
             return .failure(error)
         }
-    }
-
-    /// Creates a temporary URL for storing provisioning profile data
-    private static func createTemporaryURL() -> URL {
-        URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("mobileprovision")
     }
 }
 

--- a/ProvisionQLCore/Sources/RawProfile.swift
+++ b/ProvisionQLCore/Sources/RawProfile.swift
@@ -19,4 +19,35 @@ struct RawProfile: Codable {
     let ProvisionedDevices: [String]?
     let ProvisionsAllDevices: Bool?
     let Platform: [String]?
+    let ProfileType: String?
+
+    init(
+        UUID: String?,
+        Name: String?,
+        TeamName: String?,
+        TeamIdentifier: [String]?,
+        AppIDName: String?,
+        Entitlements: [String: PlistValue]?,
+        ExpirationDate: Date?,
+        CreationDate: Date?,
+        DeveloperCertificates: [Data]?,
+        ProvisionedDevices: [String]?,
+        ProvisionsAllDevices: Bool?,
+        Platform: [String]?,
+        ProfileType: String? = nil
+    ) {
+        self.UUID = UUID
+        self.Name = Name
+        self.TeamName = TeamName
+        self.TeamIdentifier = TeamIdentifier
+        self.AppIDName = AppIDName
+        self.Entitlements = Entitlements
+        self.ExpirationDate = ExpirationDate
+        self.CreationDate = CreationDate
+        self.DeveloperCertificates = DeveloperCertificates
+        self.ProvisionedDevices = ProvisionedDevices
+        self.ProvisionsAllDevices = ProvisionsAllDevices
+        self.Platform = Platform
+        self.ProfileType = ProfileType
+    }
 }

--- a/ProvisionQLCore/Tests/CoreTests.swift
+++ b/ProvisionQLCore/Tests/CoreTests.swift
@@ -147,6 +147,7 @@ struct CoreTests {
             #expect(provisioningInfo.creationDate == creationDate)
             #expect(provisioningInfo.devices?.count == 2)
             #expect(provisioningInfo.profileType == .development)
+            #expect(provisioningInfo.signerStatus == .unknown)
             #expect(provisioningInfo.platform == [.iOS])
         }
 
@@ -230,6 +231,27 @@ struct CoreTests {
 
             let provisioningInfo = try ProvisioningInfo(from: mockProfile)
             #expect(provisioningInfo.profileType == expected)
+        }
+
+        @Test("Signer status is stored on provisioning info")
+        func signerStatusIsStoredOnProvisioningInfo() throws {
+            let mockProfile = RawProfile(
+                UUID: "FEDCBA09-8765-4321-FEDC-BA0987654321",
+                Name: "Test Profile",
+                TeamName: "Test Team",
+                TeamIdentifier: ["ABC123"],
+                AppIDName: "Test App",
+                Entitlements: [:],
+                ExpirationDate: Date().addingTimeInterval(86400),
+                CreationDate: Date(),
+                DeveloperCertificates: nil,
+                ProvisionedDevices: nil,
+                ProvisionsAllDevices: false,
+                Platform: ["iOS"]
+            )
+
+            let provisioningInfo = try ProvisioningInfo(from: mockProfile, signerStatus: .signedByAppleWWDR)
+            #expect(provisioningInfo.signerStatus == .signedByAppleWWDR)
         }
 
         @Test("Platform detection", arguments: [
@@ -583,7 +605,8 @@ struct CoreTests {
                 DeveloperCertificates: [Data([0x01, 0x02, 0x03])],
                 ProvisionedDevices: ["device"],
                 ProvisionsAllDevices: true,
-                Platform: ["iOS", "macOS"]
+                Platform: ["iOS", "macOS"],
+                ProfileType: "MAC_APP_DIRECT"
             )
 
             let encoder = PropertyListEncoder()
@@ -600,6 +623,7 @@ struct CoreTests {
             #expect(decodedProfile.ProvisionedDevices == originalProfile.ProvisionedDevices)
             #expect(decodedProfile.ProvisionsAllDevices == originalProfile.ProvisionsAllDevices)
             #expect(decodedProfile.Platform == originalProfile.Platform)
+            #expect(decodedProfile.ProfileType == originalProfile.ProfileType)
         }
     }
 }

--- a/ProvisionQLCore/Tests/CoreTests.swift
+++ b/ProvisionQLCore/Tests/CoreTests.swift
@@ -196,6 +196,42 @@ struct CoreTests {
             #expect(provisioningInfo.profileType == expected)
         }
 
+        @Test("Explicit profile type is preferred over device heuristic", arguments: [
+            (profileType: "IOS_APP_DEVELOPMENT", expected: ProvisioningInfo.ProfileType.development),
+            (profileType: "IOS_APP_ADHOC", expected: ProvisioningInfo.ProfileType.adHoc),
+            (profileType: "IOS_APP_STORE", expected: ProvisioningInfo.ProfileType.appStore),
+            (profileType: "IOS_APP_INHOUSE", expected: ProvisioningInfo.ProfileType.enterprise),
+            (profileType: "MAC_APP_DEVELOPMENT", expected: ProvisioningInfo.ProfileType.development),
+            (profileType: "MAC_APP_STORE", expected: ProvisioningInfo.ProfileType.appStore),
+            (profileType: "MAC_APP_DIRECT", expected: ProvisioningInfo.ProfileType.directDistribution),
+            (profileType: "MAC_CATALYST_APP_DIRECT", expected: ProvisioningInfo.ProfileType.directDistribution),
+            (profileType: "DEVELOPER_ID", expected: ProvisioningInfo.ProfileType.developerID),
+            (profileType: "DIRECT_DISTRIBUTION", expected: ProvisioningInfo.ProfileType.directDistribution)
+        ])
+        func explicitProfileTypeIsPreferredOverDeviceHeuristic(
+            profileType: String,
+            expected: ProvisioningInfo.ProfileType
+        ) throws {
+            let mockProfile = RawProfile(
+                UUID: "FEDCBA09-8765-4321-FEDC-BA0987654321",
+                Name: "Test Profile",
+                TeamName: "Test Team",
+                TeamIdentifier: ["ABC123"],
+                AppIDName: "Test App",
+                Entitlements: [:],
+                ExpirationDate: Date().addingTimeInterval(86400),
+                CreationDate: Date(),
+                DeveloperCertificates: nil,
+                ProvisionedDevices: nil,
+                ProvisionsAllDevices: false,
+                Platform: ["macOS"],
+                ProfileType: profileType
+            )
+
+            let provisioningInfo = try ProvisioningInfo(from: mockProfile)
+            #expect(provisioningInfo.profileType == expected)
+        }
+
         @Test("Platform detection", arguments: [
             (platformStrings: ["iOS"], expected: [ProvisioningInfo.Platform.iOS]),
             (platformStrings: ["macOS"], expected: [ProvisioningInfo.Platform.macOS]),

--- a/ProvisionQLCore/Tests/CoreTests.swift
+++ b/ProvisionQLCore/Tests/CoreTests.swift
@@ -206,6 +206,10 @@ struct CoreTests {
             (profileType: "MAC_APP_STORE", expected: ProvisioningInfo.ProfileType.appStore),
             (profileType: "MAC_APP_DIRECT", expected: ProvisioningInfo.ProfileType.directDistribution),
             (profileType: "MAC_CATALYST_APP_DIRECT", expected: ProvisioningInfo.ProfileType.directDistribution),
+            (profileType: "VISIONOS_APP_DEVELOPMENT", expected: ProvisioningInfo.ProfileType.development),
+            (profileType: "VISIONOS_APP_ADHOC", expected: ProvisioningInfo.ProfileType.adHoc),
+            (profileType: "VISIONOS_APP_STORE", expected: ProvisioningInfo.ProfileType.appStore),
+            (profileType: "WATCHOS_APP_DEVELOPMENT", expected: ProvisioningInfo.ProfileType.development),
             (profileType: "DEVELOPER_ID", expected: ProvisioningInfo.ProfileType.developerID),
             (profileType: "DIRECT_DISTRIBUTION", expected: ProvisioningInfo.ProfileType.directDistribution)
         ])

--- a/ProvisionQLCore/Tests/CoreTests.swift
+++ b/ProvisionQLCore/Tests/CoreTests.swift
@@ -258,6 +258,38 @@ struct CoreTests {
             #expect(provisioningInfo.signerStatus == .signedByAppleWWDR)
         }
 
+        @Test("Missing signer status decodes as unknown")
+        func missingSignerStatusDecodesAsUnknown() throws {
+            let mockProfile = RawProfile(
+                UUID: "FEDCBA09-8765-4321-FEDC-BA0987654321",
+                Name: "Test Profile",
+                TeamName: "Test Team",
+                TeamIdentifier: ["ABC123"],
+                AppIDName: "Test App",
+                Entitlements: [:],
+                ExpirationDate: Date().addingTimeInterval(86400),
+                CreationDate: Date(),
+                DeveloperCertificates: nil,
+                ProvisionedDevices: nil,
+                ProvisionsAllDevices: false,
+                Platform: ["iOS"]
+            )
+            let provisioningInfo = try ProvisioningInfo(from: mockProfile, signerStatus: .signedByAppleWWDR)
+
+            let encoder = PropertyListEncoder()
+            encoder.outputFormat = .binary
+            let data = try encoder.encode(provisioningInfo)
+            var plist = try #require(
+                PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any]
+            )
+            plist.removeValue(forKey: "signerStatus")
+
+            let legacyData = try PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0)
+            let decoded = try PropertyListDecoder().decode(ProvisioningInfo.self, from: legacyData)
+
+            #expect(decoded.signerStatus == .unknown)
+        }
+
         @Test("Platform detection", arguments: [
             (platformStrings: ["iOS"], expected: [ProvisioningInfo.Platform.iOS]),
             (platformStrings: ["macOS"], expected: [ProvisioningInfo.Platform.macOS]),


### PR DESCRIPTION
Adds explicit provisioning profile type parsing and surfaces CMS signature status in the preview.

Also updates the 2.0.0 changelog entry.