### PR TITLE
Polish preview view structure

### DIFF
--- a/Preview/PreviewViewController.swift
+++ b/Preview/PreviewViewController.swift
@@ -42,7 +42,7 @@ final class PreviewModel {
             content = try await Self.loadContent(for: url)
         } catch {
             let fileInfo = await Self.fileInfo(for: url)
-            content = .failed(error, fileInfo)
+            content = .failed(PreviewFailure(error), fileInfo)
         }
     }
 }
@@ -65,7 +65,7 @@ private extension PreviewModel {
             return (result, fileInfo)
         }.value
 
-        return .archive(result.appInfo, result.iconSource?.makeImage(), fileInfo)
+        return .archive(result.appInfo, result.iconSource, fileInfo)
     }
 
     static func loadProvisioningProfileContent(for url: URL) async throws -> PreviewContent {
@@ -88,8 +88,8 @@ private extension PreviewModel {
 enum PreviewContent {
     case loading
     case profile(ProvisioningInfo, FileInfo)
-    case archive(AppInfo, NSImage?, FileInfo)
-    case failed(Error, FileInfo)
+    case archive(AppInfo, IconSource?, FileInfo)
+    case failed(PreviewFailure, FileInfo)
 }
 
 struct PreviewRootView: View {
@@ -102,10 +102,10 @@ struct PreviewRootView: View {
                 .frame(minWidth: UIConstants.Window.minWidth, minHeight: UIConstants.Window.minHeight)
         case .profile(let info, let fileInfo):
             ProvisioningPreviewView(info: info, fileInfo: fileInfo)
-        case .archive(let appInfo, let icon, let fileInfo):
-            AppArchivePreviewView(appInfo: appInfo, icon: icon, fileInfo: fileInfo)
-        case .failed(let error, let fileInfo):
-            FailedDocumentView(error: error, fileInfo: fileInfo)
+        case .archive(let appInfo, let iconSource, let fileInfo):
+            AppArchivePreviewView(appInfo: appInfo, iconSource: iconSource, fileInfo: fileInfo)
+        case .failed(let failure, let fileInfo):
+            FailedDocumentView(failure: failure, fileInfo: fileInfo)
         }
     }
 }

--- a/Preview/PreviewViewController.swift
+++ b/Preview/PreviewViewController.swift
@@ -42,7 +42,7 @@ final class PreviewModel {
             content = try await Self.loadContent(for: url)
         } catch {
             let fileInfo = await Self.fileInfo(for: url)
-            content = .failed(PreviewFailure(error), fileInfo)
+            content = .failed(PreviewFailure(error: error), fileInfo)
         }
     }
 }

--- a/Preview/Views/AppArchiveHeader.swift
+++ b/Preview/Views/AppArchiveHeader.swift
@@ -1,0 +1,49 @@
+import ProvisionQLCore
+import SwiftUI
+
+struct AppArchiveHeader: View {
+    let appInfo: AppInfo
+    let iconSource: IconSource?
+    let fileInfo: FileInfo
+
+    var body: some View {
+        HStack(alignment: .top, spacing: UIConstants.Padding.large) {
+            iconView
+
+            VStack(alignment: .leading, spacing: UIConstants.Padding.small) {
+                Text(appInfo.name)
+                    .font(.title)
+                    .fontWeight(.bold)
+
+                Text(appInfo.bundleIdentifier)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        if let icon = iconSource?.makeImage() {
+            Image(nsImage: icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: UIConstants.Size.iconSize, height: UIConstants.Size.iconSize)
+        } else {
+            RoundedRectangle(cornerRadius: UIConstants.CornerRadius.large)
+                .fill(Color.gray.opacity(0.3))
+                .frame(width: UIConstants.Size.iconSize, height: UIConstants.Size.iconSize)
+                .overlay(
+                    Image(systemName: isAppExtension ? "puzzlepiece.extension" : "app")
+                        .font(.title)
+                        .foregroundColor(.gray)
+                )
+        }
+    }
+
+    private var isAppExtension: Bool {
+        appInfo.extensionPointIdentifier != nil || fileInfo.fileName.lowercased().hasSuffix(".appex")
+    }
+}

--- a/Preview/Views/AppArchivePreviewView.swift
+++ b/Preview/Views/AppArchivePreviewView.swift
@@ -9,188 +9,63 @@ import SwiftUI
 
 struct AppArchivePreviewView: View {
     let appInfo: AppInfo
-    let icon: NSImage?
+    let iconSource: IconSource?
     let fileInfo: FileInfo
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
-                appHeader()
+        PreviewDocument {
+            AppArchiveHeader(appInfo: appInfo, iconSource: iconSource, fileInfo: fileInfo)
 
-                GroupBox {
-                    VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
-                        InfoRow(label: "Version", value: appInfo.displayVersion)
-                        InfoRow(label: "Bundle ID", value: appInfo.bundleIdentifier)
-
-                        if let extensionPointIdentifier = appInfo.extensionPointIdentifier {
-                            InfoRow(label: "Extension Point", value: extensionPointIdentifier)
-                        }
-
-                        if !appInfo.deviceFamily.isEmpty {
-                            InfoRow(label: "Device Family", value: appInfo.deviceFamily.joined(separator: ", "))
-                        }
-
-                        if let sdkVersion = appInfo.sdkVersion {
-                            Divider()
-                            InfoRow(label: "SDK Version", value: sdkVersion)
-                        }
-
-                        if let minimumOS = appInfo.minimumOSVersion {
-                            InfoRow(label: "Minimum OS", value: minimumOS)
-                        }
-                    }
-                }
-
-                if !appInfo.diagnostics.isEmpty {
-                    section(title: "Diagnostics") {
-                        AppDiagnosticsSection(diagnostics: appInfo.diagnostics)
-                    }
-                }
-
-                if !appInfo.entitlements.isEmpty {
-                    Divider()
-                    section(title: "App Entitlements") {
-                        EntitlementsSection(entitlements: appInfo.entitlements)
-                    }
-                }
-
-                if appInfo.hasEmbeddedProfile, let profile = appInfo.embeddedProvisioningProfile {
-                    Divider()
-                    embeddedProfileSection(profile: profile)
-                }
-
-                section(title: "File Info") {
-                    FileInfoSection(fileInfo: fileInfo)
-                }
-
-                footer()
-            }
-            .padding()
-        }
-        .frame(minWidth: UIConstants.Window.minWidth, minHeight: UIConstants.Window.minHeight)
-    }
-}
-
-private extension AppArchivePreviewView {
-    func appHeader() -> some View {
-        HStack(alignment: .top, spacing: UIConstants.Padding.large) {
-            if let icon {
-                Image(nsImage: icon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: UIConstants.Size.iconSize, height: UIConstants.Size.iconSize)
-            } else {
-                RoundedRectangle(cornerRadius: UIConstants.CornerRadius.large)
-                    .fill(Color.gray.opacity(0.3))
-                    .frame(width: UIConstants.Size.iconSize, height: UIConstants.Size.iconSize)
-                    .overlay(
-                        Image(systemName: isAppExtension ? "puzzlepiece.extension" : "app")
-                            .font(.title)
-                            .foregroundColor(.gray)
-                    )
+            GroupBox {
+                appDetails
             }
 
-            VStack(alignment: .leading, spacing: UIConstants.Padding.small) {
-                Text(appInfo.name)
-                    .font(.title)
-                    .fontWeight(.bold)
-
-                Text(appInfo.bundleIdentifier)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+            if !appInfo.diagnostics.isEmpty {
+                PreviewSection(title: "Diagnostics") {
+                    DiagnosticsView(diagnostics: appInfo.diagnostics)
+                }
             }
 
-            Spacer()
+            if !appInfo.entitlements.isEmpty {
+                Divider()
+                PreviewSection(title: "App Entitlements") {
+                    EntitlementsSection(entitlements: appInfo.entitlements)
+                }
+            }
+
+            if appInfo.hasEmbeddedProfile, let profile = appInfo.embeddedProvisioningProfile {
+                Divider()
+                EmbeddedProvisioningProfileSection(profile: profile)
+            }
+
+            PreviewSection(title: "File Info") {
+                FileInfoSection(fileInfo: fileInfo)
+            }
+
+            PreviewFooter()
         }
     }
 
-    func embeddedProfileSection(profile: ProvisioningInfo) -> some View {
-        section(title: "Embedded Provisioning Profile") {
-            VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
-                // Profile header with smaller title
-                VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
-                    Text(profile.name)
-                        .font(.headline)
-                        .fontWeight(.semibold)
+    private var appDetails: some View {
+        VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
+            InfoRow(label: "Version", value: appInfo.displayVersion)
+            InfoRow(label: "Bundle ID", value: appInfo.bundleIdentifier)
 
-                    ProvisioningProfileHeader(profile: profile, showTitle: false)
-                }
-
-                profileContent(for: profile)
-            }
-        }
-    }
-
-    func profileContent(for profile: ProvisioningInfo) -> some View {
-        VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
-            OverviewSection(info: profile)
-
-            if !profile.diagnostics.isEmpty {
-                section(title: "Diagnostics") {
-                    DiagnosticsSection(diagnostics: profile.diagnostics)
-                }
+            if let extensionPointIdentifier = appInfo.extensionPointIdentifier {
+                InfoRow(label: "Extension Point", value: extensionPointIdentifier)
             }
 
-            if !profile.certificates.isEmpty {
-                section(title: "Certificates (\(profile.certificates.count))") {
-                    CertificatesSection(certificates: profile.certificates)
-                }
+            if !appInfo.deviceFamily.isEmpty {
+                InfoRow(label: "Device Family", value: appInfo.deviceFamily.joined(separator: ", "))
             }
 
-            if let devices = profile.devices, !devices.isEmpty {
-                section(title: "Devices (\(devices.count))") {
-                    DevicesSection(devices: devices)
-                }
+            if let sdkVersion = appInfo.sdkVersion {
+                Divider()
+                InfoRow(label: "SDK Version", value: sdkVersion)
             }
-        }
-    }
 
-    func section(title: String, @ViewBuilder content: () -> some View) -> some View {
-        VStack(alignment: .leading) {
-            Text(title)
-                .fontWeight(.semibold)
-                .font(.title2)
-
-            content()
-        }
-    }
-
-    func footer() -> some View {
-        HStack {
-            Text("ProvisionQL \(AppVersion.versionString)")
-
-            #if DEBUG
-                Text("(debug)")
-            #endif
-
-            Spacer()
-        }
-        .foregroundColor(.secondary)
-        .font(.subheadline)
-        .frame(maxWidth: .infinity)
-    }
-
-    var isAppExtension: Bool {
-        appInfo.extensionPointIdentifier != nil || fileInfo.fileName.lowercased().hasSuffix(".appex")
-    }
-}
-
-struct AppDiagnosticsSection: View {
-    let diagnostics: [AppDiagnostic]
-
-    var body: some View {
-        GroupBox {
-            VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
-                ForEach(diagnostics, id: \.self) { diagnostic in
-                    HStack(alignment: .top, spacing: UIConstants.Padding.medium) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(.orange)
-
-                        Text(diagnostic.message)
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
+            if let minimumOS = appInfo.minimumOSVersion {
+                InfoRow(label: "Minimum OS", value: minimumOS)
             }
         }
     }

--- a/Preview/Views/DiagnosticsView.swift
+++ b/Preview/Views/DiagnosticsView.swift
@@ -1,0 +1,30 @@
+import ProvisionQLCore
+import SwiftUI
+
+protocol PreviewDiagnosticItem: Hashable {
+    var message: String { get }
+}
+
+extension AppDiagnostic: PreviewDiagnosticItem {}
+extension ProvisioningDiagnostic: PreviewDiagnosticItem {}
+
+struct DiagnosticsView<Diagnostic: PreviewDiagnosticItem>: View {
+    let diagnostics: [Diagnostic]
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
+                ForEach(diagnostics, id: \.self) { diagnostic in
+                    HStack(alignment: .top, spacing: UIConstants.Padding.medium) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.orange)
+
+                        Text(diagnostic.message)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Preview/Views/EmbeddedProvisioningProfileSection.swift
+++ b/Preview/Views/EmbeddedProvisioningProfileSection.swift
@@ -1,0 +1,46 @@
+import ProvisionQLCore
+import SwiftUI
+
+struct EmbeddedProvisioningProfileSection: View {
+    let profile: ProvisioningInfo
+
+    var body: some View {
+        PreviewSection(title: "Embedded Provisioning Profile") {
+            VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
+                VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
+                    Text(profile.name)
+                        .font(.headline)
+                        .fontWeight(.semibold)
+
+                    ProvisioningProfileHeader(profile: profile, showTitle: false)
+                }
+
+                profileContent
+            }
+        }
+    }
+
+    private var profileContent: some View {
+        VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
+            OverviewSection(info: profile)
+
+            if !profile.diagnostics.isEmpty {
+                PreviewSection(title: "Diagnostics") {
+                    DiagnosticsView(diagnostics: profile.diagnostics)
+                }
+            }
+
+            if !profile.certificates.isEmpty {
+                PreviewSection(title: "Certificates (\(profile.certificates.count))") {
+                    CertificatesSection(certificates: profile.certificates)
+                }
+            }
+
+            if let devices = profile.devices, !devices.isEmpty {
+                PreviewSection(title: "Devices (\(devices.count))") {
+                    DevicesSection(devices: devices)
+                }
+            }
+        }
+    }
+}

--- a/Preview/Views/FailedDocumentView.swift
+++ b/Preview/Views/FailedDocumentView.swift
@@ -1,0 +1,50 @@
+import Foundation
+import ProvisionQLCore
+import SwiftUI
+
+struct PreviewFailure: Hashable {
+    let message: String
+    let missingFields: [String]
+
+    init(_ error: Error) {
+        message = error.localizedDescription
+
+        if let error = error as? ProvisioningProfileValidationError {
+            missingFields = error.missingFields
+        } else {
+            missingFields = []
+        }
+    }
+}
+
+struct FailedDocumentView: View {
+    let failure: PreviewFailure
+    let fileInfo: FileInfo
+
+    var body: some View {
+        PreviewDocument {
+            Text("\(fileInfo.fileName) could not be parsed")
+                .font(.title)
+                .fontWeight(.bold)
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
+                    Text(failure.message)
+                        .textSelection(.enabled)
+
+                    if !failure.missingFields.isEmpty {
+                        Divider()
+
+                        InfoRow(label: "Missing", value: failure.missingFields.joined(separator: ", "))
+                    }
+                }
+            }
+
+            PreviewSection(title: "File Info") {
+                FileInfoSection(fileInfo: fileInfo)
+            }
+
+            PreviewFooter()
+        }
+    }
+}

--- a/Preview/Views/FailedDocumentView.swift
+++ b/Preview/Views/FailedDocumentView.swift
@@ -6,7 +6,7 @@ struct PreviewFailure: Hashable {
     let message: String
     let missingFields: [String]
 
-    init(_ error: Error) {
+    init(error: Error) {
         message = error.localizedDescription
 
         if let error = error as? ProvisioningProfileValidationError {

--- a/Preview/Views/InfoRow.swift
+++ b/Preview/Views/InfoRow.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct InfoRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .fontWeight(.medium)
+                .frame(minWidth: UIConstants.Size.minLabelWidth, alignment: .leading)
+                .foregroundColor(.secondary)
+
+            Text(value)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/Preview/Views/OverviewSection.swift
+++ b/Preview/Views/OverviewSection.swift
@@ -24,31 +24,3 @@ struct OverviewSection: View {
         }
     }
 }
-
-extension ExpirationStatus {
-    var color: Color {
-        switch self {
-        case .expired: .red
-        case .expiring: .orange
-        case .valid: UIConstants.Color.validGreen
-        }
-    }
-}
-
-struct InfoRow: View {
-    let label: String
-    let value: String
-
-    var body: some View {
-        HStack(alignment: .top) {
-            Text(label)
-                .fontWeight(.medium)
-                .frame(minWidth: UIConstants.Size.minLabelWidth, alignment: .leading)
-                .foregroundColor(.secondary)
-
-            Text(value)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-}

--- a/Preview/Views/PreviewColors.swift
+++ b/Preview/Views/PreviewColors.swift
@@ -1,0 +1,37 @@
+import ProvisionQLCore
+import SwiftUI
+
+extension ExpirationStatus {
+    var color: Color {
+        switch self {
+        case .expired: .red
+        case .expiring: .orange
+        case .valid: UIConstants.Color.validGreen
+        }
+    }
+}
+
+extension ProvisioningInfo.ProfileType {
+    var color: Color {
+        switch self {
+        case .development: .blue
+        case .adHoc: .purple
+        case .appStore: UIConstants.Color.validGreen
+        case .enterprise: .orange
+        case .developerID: .indigo
+        case .directDistribution: .indigo
+        }
+    }
+}
+
+extension ProvisioningInfo.SignerStatus {
+    var color: Color {
+        switch self {
+        case .signedByAppleWWDR: UIConstants.Color.validGreen
+        case .signed: .indigo
+        case .unsigned: .orange
+        case .invalidSignature, .invalidCertificate: .red
+        case .needsDetachedContent, .unknown: .secondary
+        }
+    }
+}

--- a/Preview/Views/PreviewDocument.swift
+++ b/Preview/Views/PreviewDocument.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct PreviewDocument<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
+                content
+            }
+            .padding()
+        }
+        .frame(minWidth: UIConstants.Window.minWidth, minHeight: UIConstants.Window.minHeight)
+    }
+}

--- a/Preview/Views/PreviewFooter.swift
+++ b/Preview/Views/PreviewFooter.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct PreviewFooter: View {
+    var body: some View {
+        HStack {
+            Text("ProvisionQL \(AppVersion.versionString)")
+
+            #if DEBUG
+                Text("(debug)")
+            #endif
+
+            Spacer()
+        }
+        .foregroundColor(.secondary)
+        .font(.subheadline)
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Preview/Views/PreviewSection.swift
+++ b/Preview/Views/PreviewSection.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct PreviewSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(title)
+                .fontWeight(.semibold)
+                .font(.title2)
+
+            content
+        }
+    }
+}

--- a/Preview/Views/ProvisioningPreviewView.swift
+++ b/Preview/Views/ProvisioningPreviewView.swift
@@ -5,7 +5,6 @@
 //  Created by Evgeny Aleksandrov
 
 import ProvisionQLCore
-import Quartz
 import SwiftUI
 
 struct ProvisioningPreviewView: View {
@@ -13,210 +12,40 @@ struct ProvisioningPreviewView: View {
     let fileInfo: FileInfo
 
     var body: some View {
-        documentContent(for: info)
-    }
-}
+        PreviewDocument {
+            ProvisioningProfileHeader(profile: info)
 
-private extension ProvisioningPreviewView {
-    func documentContent(for info: ProvisioningInfo) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
-                header(for: info)
+            OverviewSection(info: info)
 
-                OverviewSection(info: info)
-
-                if !info.diagnostics.isEmpty {
-                    section(title: "Diagnostics") {
-                        DiagnosticsSection(diagnostics: info.diagnostics)
-                    }
-                }
-
-                if !info.entitlements.isEmpty {
-                    section(title: "Entitlements") {
-                        EntitlementsSection(entitlements: info.entitlements)
-                    }
-                }
-
-                if !info.certificates.isEmpty {
-                    section(title: "Certificates (\(info.certificates.count))") {
-                        CertificatesSection(certificates: info.certificates)
-                    }
-                }
-
-                if let devices = info.devices, !devices.isEmpty {
-                    section(title: "Devices (\(devices.count))") {
-                        DevicesSection(devices: devices)
-                    }
-                }
-
-                section(title: "File Info") {
-                    FileInfoSection(fileInfo: fileInfo)
-                }
-
-                footer()
-            }
-            .padding()
-        }
-        .frame(minWidth: UIConstants.Window.minWidth, minHeight: UIConstants.Window.minHeight)
-    }
-
-    func header(for info: ProvisioningInfo) -> some View {
-        ProvisioningProfileHeader(profile: info)
-    }
-
-    func section(title: String, @ViewBuilder content: () -> some View) -> some View {
-        VStack(alignment: .leading) {
-            Text(title)
-                .fontWeight(.semibold)
-                .font(.title2)
-
-            content()
-        }
-    }
-
-    func footer() -> some View {
-        HStack {
-            Text("ProvisionQL \(AppVersion.versionString)")
-
-            #if DEBUG
-                Text("(debug)")
-            #endif
-
-            Spacer()
-        }
-        .foregroundColor(.secondary)
-        .font(.subheadline)
-        .frame(maxWidth: .infinity)
-    }
-}
-
-extension ProvisioningInfo.ProfileType {
-    var color: Color {
-        switch self {
-        case .development: .blue
-        case .adHoc: .purple
-        case .appStore: UIConstants.Color.validGreen
-        case .enterprise: .orange
-        case .developerID: .indigo
-        case .directDistribution: .indigo
-        }
-    }
-}
-
-extension ProvisioningInfo.SignerStatus {
-    var color: Color {
-        switch self {
-        case .signedByAppleWWDR: UIConstants.Color.validGreen
-        case .signed: .indigo
-        case .unsigned: .orange
-        case .invalidSignature, .invalidCertificate: .red
-        case .needsDetachedContent, .unknown: .secondary
-        }
-    }
-}
-
-struct StatusBadge: View {
-    let text: String
-    let color: Color
-
-    var body: some View {
-        Text(text)
-            .font(.subheadline)
-            .fontWeight(.medium)
-            .padding(.horizontal, UIConstants.Padding.medium)
-            .padding(.vertical, UIConstants.Padding.small)
-            .background(color.opacity(0.2))
-            .foregroundColor(color)
-            .cornerRadius(UIConstants.CornerRadius.small)
-    }
-}
-
-struct DiagnosticsSection: View {
-    let diagnostics: [ProvisioningDiagnostic]
-
-    var body: some View {
-        GroupBox {
-            VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
-                ForEach(diagnostics, id: \.self) { diagnostic in
-                    HStack(alignment: .top, spacing: UIConstants.Padding.medium) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(.orange)
-
-                        Text(diagnostic.message)
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
+            if !info.diagnostics.isEmpty {
+                PreviewSection(title: "Diagnostics") {
+                    DiagnosticsView(diagnostics: info.diagnostics)
                 }
             }
-        }
-    }
-}
 
-struct FailedDocumentView: View {
-    let error: Error
-    let fileInfo: FileInfo
-
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: UIConstants.Padding.standard) {
-                Text("\(fileInfo.fileName) could not be parsed")
-                    .font(.title)
-                    .fontWeight(.bold)
-
-                GroupBox {
-                    VStack(alignment: .leading, spacing: UIConstants.Padding.medium) {
-                        Text(error.localizedDescription)
-                            .textSelection(.enabled)
-
-                        if !missingFields.isEmpty {
-                            Divider()
-
-                            InfoRow(label: "Missing", value: missingFields.joined(separator: ", "))
-                        }
-                    }
+            if !info.entitlements.isEmpty {
+                PreviewSection(title: "Entitlements") {
+                    EntitlementsSection(entitlements: info.entitlements)
                 }
-
-                section(title: "File Info") {
-                    FileInfoSection(fileInfo: fileInfo)
-                }
-
-                footer()
             }
-            .padding()
+
+            if !info.certificates.isEmpty {
+                PreviewSection(title: "Certificates (\(info.certificates.count))") {
+                    CertificatesSection(certificates: info.certificates)
+                }
+            }
+
+            if let devices = info.devices, !devices.isEmpty {
+                PreviewSection(title: "Devices (\(devices.count))") {
+                    DevicesSection(devices: devices)
+                }
+            }
+
+            PreviewSection(title: "File Info") {
+                FileInfoSection(fileInfo: fileInfo)
+            }
+
+            PreviewFooter()
         }
-        .frame(minWidth: UIConstants.Window.minWidth, minHeight: UIConstants.Window.minHeight)
-    }
-
-    func section(title: String, @ViewBuilder content: () -> some View) -> some View {
-        VStack(alignment: .leading) {
-            Text(title)
-                .fontWeight(.semibold)
-                .font(.title2)
-
-            content()
-        }
-    }
-
-    func footer() -> some View {
-        HStack {
-            Text("ProvisionQL \(AppVersion.versionString)")
-
-            #if DEBUG
-                Text("(debug)")
-            #endif
-
-            Spacer()
-        }
-        .foregroundColor(.secondary)
-        .font(.subheadline)
-        .frame(maxWidth: .infinity)
-    }
-
-    var missingFields: [String] {
-        guard let error = error as? ProvisioningProfileValidationError else {
-            return []
-        }
-
-        return error.missingFields
     }
 }

--- a/Preview/Views/StatusBadge.swift
+++ b/Preview/Views/StatusBadge.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct StatusBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.subheadline)
+            .fontWeight(.medium)
+            .padding(.horizontal, UIConstants.Padding.medium)
+            .padding(.vertical, UIConstants.Padding.small)
+            .background(color.opacity(0.2))
+            .foregroundColor(color)
+            .cornerRadius(UIConstants.CornerRadius.small)
+    }
+}

--- a/ProvisionQLCore/Package.swift
+++ b/ProvisionQLCore/Package.swift
@@ -19,10 +19,7 @@ let package = Package(
         .target(
             name: "ProvisionQLCore",
             dependencies: ["ZIPFoundation"],
-            path: "Sources",
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            path: "Sources"
         ),
         .testTarget(
             name: "ProvisionQLCoreTests",
@@ -32,5 +29,6 @@ let package = Package(
                 .process("Fixtures")
             ]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
## Summary

- Extract shared preview UI components for sections, footers, rows, badges, diagnostics, and failure states
- Move archive icon rendering to `IconSource` so preview state no longer stores `NSImage`
- Modernize the core package manifest to use Swift 6 language mode