### PR TITLE
Add TrollStore IPA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Preserves unknown provisioning platforms and nested entitlement values
 * Shows explicit provisioning profile type and signature status
 * Fixes parsing for macOS `.xcarchive` and `.appex` bundles
+* Adds support for `.tipa` (TrollStore IPA) files
 * Shows archive parsing failures in the preview
 * Adds a host app file inspector for opening and dropping supported files
 

--- a/Preview/Info.plist
+++ b/Preview/Info.plist
@@ -14,6 +14,8 @@
 				<string>com.apple.iphone.mobileprovision</string>
 				<string>com.apple.provisionprofile</string>
 				<string>com.apple.itunes.ipa</string>
+				<string>com.opa334.trollstore.tipa</string>
+				<string>dyn.ah62d4rv4ge81k4puqe</string>
 				<string>com.apple.xcode.archive</string>
 				<string>com.apple.application-and-system-extension</string>
 			</array>
@@ -42,6 +44,24 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>mobileprovision</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.itunes.ipa</string>
+				<string>public.zip-archive</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>TrollStore IPA</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.opa334.trollstore.tipa</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tipa</string>
 				</array>
 			</dict>
 		</dict>

--- a/ProvisionQL/ContentView.swift
+++ b/ProvisionQL/ContentView.swift
@@ -178,7 +178,7 @@ private struct EmptyStateView: View {
                     .font(.title2)
                     .fontWeight(.semibold)
 
-                Text(".ipa, .xcarchive, .appex, .mobileprovision, .provisionprofile")
+                Text(".ipa, .tipa, .xcarchive, .appex, .mobileprovision, .provisionprofile")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }

--- a/ProvisionQL/Info.plist
+++ b/ProvisionQL/Info.plist
@@ -12,6 +12,8 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.apple.itunes.ipa</string>
+				<string>com.opa334.trollstore.tipa</string>
+				<string>dyn.ah62d4rv4ge81k4puqe</string>
 				<string>com.apple.xcode.archive</string>
 				<string>com.apple.application-and-system-extension</string>
 				<string>com.apple.mobileprovision</string>
@@ -37,6 +39,24 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>mobileprovision</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.itunes.ipa</string>
+				<string>public.zip-archive</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>TrollStore IPA</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.opa334.trollstore.tipa</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tipa</string>
 				</array>
 			</dict>
 		</dict>

--- a/ProvisionQLCore/PreviewUI/PreviewSupportedContentTypes.swift
+++ b/ProvisionQLCore/PreviewUI/PreviewSupportedContentTypes.swift
@@ -2,6 +2,8 @@ import UniformTypeIdentifiers
 
 public enum PreviewSupportedContentTypes {
     public static let ipa = UTType(importedAs: "com.apple.itunes.ipa")
+    public static let trollStoreIPA = UTType(importedAs: "com.opa334.trollstore.tipa")
+    public static let dynamicTrollStoreIPA = UTType(importedAs: "dyn.ah62d4rv4ge81k4puqe")
     public static let xcodeArchive = UTType(importedAs: "com.apple.xcode.archive")
     public static let appExtension = UTType(importedAs: "com.apple.application-and-system-extension")
     public static let mobileProvision = UTType(importedAs: "com.apple.mobileprovision")
@@ -10,6 +12,7 @@ public enum PreviewSupportedContentTypes {
 
     public static let all: [UTType] = [
         ipa,
+        trollStoreIPA,
         xcodeArchive,
         appExtension,
         mobileProvision,
@@ -20,6 +23,8 @@ public enum PreviewSupportedContentTypes {
     static func isAppArchive(_ contentType: UTType) -> Bool {
         switch contentType.identifier {
         case ipa.identifier,
+             trollStoreIPA.identifier,
+             dynamicTrollStoreIPA.identifier,
              xcodeArchive.identifier,
              appExtension.identifier:
             true

--- a/ProvisionQLCore/Sources/AppArchiveParser.swift
+++ b/ProvisionQLCore/Sources/AppArchiveParser.swift
@@ -15,7 +15,7 @@ public enum AppArchiveParser {
         let fileExtension = url.pathExtension.lowercased()
 
         switch fileExtension {
-        case "ipa":
+        case "ipa", "tipa":
             return try parseIPA(url)
         case "xcarchive":
             return try parseXCArchive(url)

--- a/ProvisionQLCore/Sources/IconExtractor.swift
+++ b/ProvisionQLCore/Sources/IconExtractor.swift
@@ -16,7 +16,7 @@ public enum IconExtractor {
         let fileExtension = url.pathExtension.lowercased()
 
         switch fileExtension {
-        case "ipa":
+        case "ipa", "tipa":
             let source = try IPAAppBundleSource(url: url)
             return try extractIconSource(from: source)
         case "xcarchive":

--- a/ProvisionQLCore/Tests/AppArchiveTests.swift
+++ b/ProvisionQLCore/Tests/AppArchiveTests.swift
@@ -130,6 +130,43 @@ struct AppArchiveTests {
             #expect(appInfo.diagnostics.isEmpty)
         }
 
+        @Test("Parser treats TIPA archives as IPAs")
+        func parserTreatsTIPAArchivesAsIPAs() throws {
+            let ipaURL = createTempZipArchive(
+                withFiles: [
+                    "Payload/TestApp.app/Info.plist": createMockInfoPlistData()
+                ],
+                extension: "ipa"
+            )
+            let tipaURL = createTempFile(withExtension: "tipa", content: try Data(contentsOf: ipaURL))
+            defer {
+                try? FileManager.default.removeItem(at: ipaURL)
+                try? FileManager.default.removeItem(at: tipaURL)
+            }
+
+            let ipaInfo = try AppArchiveParser.parse(ipaURL)
+            let tipaInfo = try AppArchiveParser.parse(tipaURL)
+
+            #expect(tipaInfo == ipaInfo)
+        }
+
+        @Test("Icon extractor treats TIPA archives as IPAs")
+        func iconExtractorTreatsTIPAArchivesAsIPAs() throws {
+            let artworkData = Data("mock artwork".utf8)
+            let tempURL = createTempZipArchive(
+                withFiles: [
+                    "iTunesArtwork": artworkData,
+                    "Payload/TestApp.app/Info.plist": createMockInfoPlistData()
+                ],
+                extension: "tipa"
+            )
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+
+            let iconSource = try IconExtractor.extractIconSource(from: tempURL)
+
+            #expect(iconSource?.data == artworkData)
+        }
+
         @Test("Parser reports malformed embedded provisioning profile")
         func parserReportsMalformedEmbeddedProvisioningProfile() throws {
             let tempURL = createTempZipArchive(

--- a/ProvisionQLCore/Tests/AppArchiveTests.swift
+++ b/ProvisionQLCore/Tests/AppArchiveTests.swift
@@ -138,7 +138,7 @@ struct AppArchiveTests {
                 ],
                 extension: "ipa"
             )
-            let tipaURL = createTempFile(withExtension: "tipa", content: try Data(contentsOf: ipaURL))
+            let tipaURL = try createTempFile(withExtension: "tipa", content: Data(contentsOf: ipaURL))
             defer {
                 try? FileManager.default.removeItem(at: ipaURL)
                 try? FileManager.default.removeItem(at: tipaURL)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Open or drop a supported file into the app for the full inspector, or use Finder
 | File | Description |
 | --- | --- |
 | `.ipa` | Packaged iOS, tvOS, watchOS, or visionOS app |
+| `.tipa` | TrollStore IPA |
 | `.xcarchive` | Xcode archive, including macOS archive layouts |
 | `.appex` | App extension bundle |
 | `.mobileprovision` | iOS provisioning profile |

--- a/Thumbnail/Info.plist
+++ b/Thumbnail/Info.plist
@@ -12,6 +12,8 @@
 				<string>com.apple.iphone.mobileprovision</string>
 				<string>com.apple.provisionprofile</string>
 				<string>com.apple.itunes.ipa</string>
+				<string>com.opa334.trollstore.tipa</string>
+				<string>dyn.ah62d4rv4ge81k4puqe</string>
 				<string>com.apple.xcode.archive</string>
 				<string>com.apple.application-and-system-extension</string>
 			</array>
@@ -40,6 +42,24 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>mobileprovision</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.itunes.ipa</string>
+				<string>public.zip-archive</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>TrollStore IPA</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.opa334.trollstore.tipa</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tipa</string>
 				</array>
 			</dict>
 		</dict>

--- a/Thumbnail/ThumbnailProvider.swift
+++ b/Thumbnail/ThumbnailProvider.swift
@@ -27,7 +27,7 @@ class ThumbnailProvider: QLThumbnailProvider {
             icon = getProvisioningIcon()
             extensionBadge = "PROV"
 
-        case "ipa", "xcarchive", "appex":
+        case "ipa", "tipa", "xcarchive", "appex":
             icon = (try? IconExtractor.extractIcon(from: url)) ?? getDefaultAppIcon()
             extensionBadge = fileExtension.uppercased()
 


### PR DESCRIPTION
## Summary

- Adds `.tipa` / TrollStore IPA content type support to the host app, preview extension, and thumbnail extension
- Routes `.tipa` files through the existing IPA parser and icon extractor
- Supports the observed dynamic `.tipa` UTI fallback (`dyn.ah62d4rv4ge81k4puqe`)
- Adds parser/icon extraction tests and updates README/CHANGELOG

Fixes https://github.com/ealeksandrov/ProvisionQL/issues/50
Closes https://github.com/ealeksandrov/ProvisionQL/pull/52